### PR TITLE
Temporarily disable plugin goal diagnostics

### DIFF
--- a/lemminx-maven/src/main/java/org/eclipse/lemminx/maven/MavenDiagnosticParticipant.java
+++ b/lemminx-maven/src/main/java/org/eclipse/lemminx/maven/MavenDiagnosticParticipant.java
@@ -91,7 +91,6 @@ public class MavenDiagnosticParticipant implements IDiagnosticsParticipant {
 
 		HashMap<String, Function<DiagnosticRequest, Diagnostic>> tagDiagnostics = new HashMap<>();
 		tagDiagnostics.put("configuration", validatePluginConfiguration);
-		tagDiagnostics.put("goal", validatePluginGoal);
 		return tagDiagnostics;
 	}
 

--- a/lemminx-maven/src/test/java/org/eclipse/lemminx/maven/test/LocalPluginTest.java
+++ b/lemminx-maven/src/test/java/org/eclipse/lemminx/maven/test/LocalPluginTest.java
@@ -27,6 +27,7 @@ import org.eclipse.lsp4j.Position;
 import org.eclipse.lsp4j.TextEdit;
 import org.junit.After;
 import org.junit.Before;
+import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 
@@ -114,7 +115,9 @@ public class LocalPluginTest {
 			assertTrue(languageService.doDiagnostics(document, () -> {}, new XMLValidationSettings()).size() == 2);
 		}
 		
+		// Temporarily disabled
 		@Test
+		@Ignore
 	 	public void testPluginGoalDiagnostics() throws IOException, InterruptedException, ExecutionException, URISyntaxException {
 			DOMDocument document = createDOMDocument("/pom-plugin-goal-diagnostic.xml", languageService);
 			assertTrue(languageService.doDiagnostics(document, () -> {}, new XMLValidationSettings()).stream().map(Diagnostic::getMessage)


### PR DESCRIPTION
Disabled as it's still causing false positives.

Part of #48

Signed-off-by: Andrew Obuchowicz <aobuchow@redhat.com>