### PR TITLE
Diagnostics refactor + missing but resolvable groupId fix

### DIFF
--- a/lemminx-maven/pom.xml
+++ b/lemminx-maven/pom.xml
@@ -115,8 +115,16 @@
 		<groupId>org.apache.maven.plugins</groupId>
 		<artifactId>maven-shade-plugin</artifactId>
 		<version>3.2.2</version>
-		<type>pom</type>
+		<type>test-jar</type>
 		<scope>test</scope>
+	</dependency>
+		<!-- This is a workaround for CI because it looks like CI cannot connect 
+		to Central during tests -->
+	<!-- Use in LocalPluginTest#testDiagnosticMissingGroupId -->
+	<dependency>
+		<groupId>org.apache.maven.plugins</groupId>
+		<artifactId>maven-compiler-plugin</artifactId>
+		<version>3.8.1</version>
 	</dependency>
 	</dependencies>
 

--- a/lemminx-maven/src/main/java/org/eclipse/lemminx/maven/DiagnosticRequest.java
+++ b/lemminx-maven/src/main/java/org/eclipse/lemminx/maven/DiagnosticRequest.java
@@ -8,8 +8,6 @@
  *******************************************************************************/
 package org.eclipse.lemminx.maven;
 
-import java.util.List;
-
 import org.eclipse.lemminx.commons.BadLocationException;
 import org.eclipse.lemminx.dom.DOMDocument;
 import org.eclipse.lemminx.dom.DOMElement;
@@ -18,48 +16,42 @@ import org.eclipse.lemminx.dom.LineIndentInfo;
 import org.eclipse.lemminx.services.extensions.IPositionRequest;
 import org.eclipse.lemminx.utils.XMLPositionUtility;
 import org.eclipse.lsp4j.Diagnostic;
+import org.eclipse.lsp4j.DiagnosticSeverity;
 import org.eclipse.lsp4j.Position;
 import org.eclipse.lsp4j.Range;
 
 public class DiagnosticRequest implements IPositionRequest {
 	private DOMNode node;
 	private DOMDocument xmlDocument;
-	private List<Diagnostic> diagnostics;
-
-	public DiagnosticRequest(DOMNode node, DOMDocument xmlDocument, List<Diagnostic> diagnostics) {
-		this.setNode(node);
-		this.setXMLDocument(xmlDocument);
-		this.setDiagnostics(diagnostics);
+	
+	/**
+	 * A diagnosticRequest allows creation of diagnostics for a supplied node.
+	 * 
+	 * @param node        The node where diagnostics should be added.
+	 * @param xmlDocument The XMLDocument where the diagnostics will appear
+	 */
+	public DiagnosticRequest(DOMNode node, DOMDocument xmlDocument) {
+		this.node = node;
+		this.xmlDocument = xmlDocument;
 	}
-
+	
+	public Diagnostic createDiagnostic(String errorMessage, DiagnosticSeverity severity) {
+		return new Diagnostic(this.getRange(), errorMessage, severity, this.getXMLDocument().getDocumentURI(), "XML");
+	}
+	
+	private Range getRange() {
+		return XMLPositionUtility.createRange(((DOMElement) node).getStartTagCloseOffset() + 1,
+				((DOMElement) node).getEndTagOpenOffset(), xmlDocument);
+	}
+	
+	@Override
 	public DOMDocument getXMLDocument() {
 		return xmlDocument;
-	}
-
-	private void setXMLDocument(DOMDocument xmlDocument) {
-		this.xmlDocument = xmlDocument;
 	}
 
 	@Override
 	public DOMNode getNode() {
 		return node;
-	}
-
-	private void setNode(DOMNode node) {
-		this.node = node;
-	}
-
-	public List<Diagnostic> getDiagnostics() {
-		return diagnostics;
-	}
-
-	private void setDiagnostics(List<Diagnostic> diagnostics) {
-		this.diagnostics = diagnostics;
-	}
-
-	public Range getRange() {
-		return XMLPositionUtility.createRange(((DOMElement) node).getStartTagCloseOffset() + 1,
-				((DOMElement) node).getEndTagOpenOffset(), xmlDocument);
 	}
 
 	@Override

--- a/lemminx-maven/src/main/java/org/eclipse/lemminx/maven/SubModuleValidator.java
+++ b/lemminx-maven/src/main/java/org/eclipse/lemminx/maven/SubModuleValidator.java
@@ -12,15 +12,16 @@ import java.io.File;
 import java.io.FileNotFoundException;
 import java.io.FileReader;
 import java.io.IOException;
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
 
 import org.apache.maven.model.Model;
 import org.apache.maven.model.io.xpp3.MavenXpp3Reader;
 import org.codehaus.plexus.util.xml.pull.XmlPullParserException;
-import org.eclipse.lemminx.dom.DOMDocument;
 import org.eclipse.lemminx.dom.DOMNode;
 import org.eclipse.lsp4j.Diagnostic;
 import org.eclipse.lsp4j.DiagnosticSeverity;
-import org.eclipse.lsp4j.Range;
 
 public class SubModuleValidator {
 	Model model;
@@ -32,23 +33,18 @@ public class SubModuleValidator {
 		model = mavenreader.read(new FileReader(pomFile));
 	}
 
-	public Diagnostic validateSubModuleExistence(DiagnosticRequest diagnosticRequest) {
+	public Optional<List<Diagnostic>> validateSubModuleExistence(DiagnosticRequest diagnosticRequest) {
 		DOMNode node = diagnosticRequest.getNode();
-		DOMDocument xmlDocument = diagnosticRequest.getXMLDocument();
-		Diagnostic diagnostic = null;
-		Range range = diagnosticRequest.getRange();
 		String tagContent = null;
 		if (node.hasChildNodes()) {
 			tagContent = node.getChild(0).getNodeValue(); // tagContent is the module to validate eg.
 															// <module>tagContent</module>
 		}
 		if (node.hasChildNodes() && !model.getModules().contains(tagContent)) {
-			diagnostic = new Diagnostic(range, String.format("Module '%s' does not exist", tagContent),
-					DiagnosticSeverity.Error, xmlDocument.getDocumentURI(), "XML");
-			diagnosticRequest.getDiagnostics().add(diagnostic);
+			return Optional.of(Collections.singletonList(diagnosticRequest.createDiagnostic(
+					String.format("Module '%s' does not exist", tagContent), DiagnosticSeverity.Error)));
 		}
-		return diagnostic;
-
+		return Optional.empty();
 	}
 
 }

--- a/lemminx-maven/src/main/java/org/eclipse/lemminx/maven/VersionValidator.java
+++ b/lemminx-maven/src/main/java/org/eclipse/lemminx/maven/VersionValidator.java
@@ -8,38 +8,33 @@
  *******************************************************************************/
 package org.eclipse.lemminx.maven;
 
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+
 import org.apache.maven.artifact.Artifact;
 import org.apache.maven.artifact.DefaultArtifact;
 import org.apache.maven.artifact.handler.DefaultArtifactHandler;
 import org.apache.maven.model.Dependency;
-import org.eclipse.lemminx.dom.DOMDocument;
 import org.eclipse.lemminx.dom.DOMNode;
 import org.eclipse.lsp4j.Diagnostic;
 import org.eclipse.lsp4j.DiagnosticSeverity;
-import org.eclipse.lsp4j.Range;
 
 public class VersionValidator {
 
-	public static Diagnostic validateVersion(DiagnosticRequest diagnosticRequest) {
+	public static Optional<List<Diagnostic>> validateVersion(DiagnosticRequest diagnosticRequest) {
 		DOMNode node = diagnosticRequest.getNode();
-		DOMDocument xmlDocument = diagnosticRequest.getXMLDocument();
 		Dependency model = MavenParseUtils.parseArtifact(node);
 		Artifact artifact = null;
-		Range range = diagnosticRequest.getRange();
-		Diagnostic diagnostic = null;
 		try {
 			 artifact = new DefaultArtifact(model.getGroupId(), model.getArtifactId(), model.getVersion(), model.getScope(), model.getType(), model.getClassifier(), new DefaultArtifactHandler(model.getType()));
-			 if (!artifact.isSelectedVersionKnown()) {
-				diagnostic = new Diagnostic(range, "Version Error", DiagnosticSeverity.Error,
-						xmlDocument.getDocumentURI(), "XML");
-				diagnosticRequest.getDiagnostics().add(diagnostic);
+			if (!artifact.isSelectedVersionKnown()) {
+				return Optional.of(Collections
+						.singletonList(diagnosticRequest.createDiagnostic("Version Error", DiagnosticSeverity.Error)));
 			}
 		} catch (Exception e) {
 			e.printStackTrace();
-			diagnostic = new Diagnostic(range, e.getMessage(), DiagnosticSeverity.Error,
-					xmlDocument.getDocumentURI(), "XML");
-			diagnosticRequest.getDiagnostics().add(diagnostic);
 		}
-		return diagnostic;
+		return Optional.empty();
 	}
 }

--- a/lemminx-maven/src/test/java/org/eclipse/lemminx/maven/test/LocalPluginTest.java
+++ b/lemminx-maven/src/test/java/org/eclipse/lemminx/maven/test/LocalPluginTest.java
@@ -15,6 +15,7 @@ import static org.junit.Assert.assertTrue;
 import java.io.IOException;
 import java.net.URISyntaxException;
 import java.util.Collections;
+import java.util.List;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeoutException;
 
@@ -134,18 +135,28 @@ public class LocalPluginTest {
 	public void testPluginDiagnosticMissingPlugin()
 			throws IOException, InterruptedException, ExecutionException, URISyntaxException {
 		DOMDocument document = createDOMDocument("/pom-plugin-diagnostic-missing-plugin.xml", languageService);
-		System.out.println(languageService.doDiagnostics(document, () -> {
-		}, new XMLValidationSettings()));
-		// One diagnostic should be from a missing groupID (incomplete GAV), another should be
-		// from unresolvable plugin (maven-shade-plugin:3.2.2)
-		assertTrue(languageService.doDiagnostics(document, () -> {
-		}, new XMLValidationSettings()).stream().map(Diagnostic::getMessage).anyMatch(message -> message.contains(
+		List<Diagnostic> diagnostics = languageService.doDiagnostics(document, () -> {
+		}, new XMLValidationSettings());
+		// Only one diagnostic should be present from unresolvable plugin (maven-shade-plugin:3.2.2)
+		assertTrue(diagnostics.stream().map(Diagnostic::getMessage).anyMatch(message -> message.contains(
 				"Plugin org.apache.maven.plugins:maven-shade-plugin:3.2.2 or one of its dependencies could not be resolved")));
+		assertTrue(diagnostics.size() == 1); 
+	}
+	
+	@Test
+	public void testDiagnosticMissingGroupId() throws IOException, URISyntaxException {
+		DOMDocument document = createDOMDocument("/pom-plugin-diagnostic-missing-groupid.xml", languageService);
+		List<Diagnostic> diagnostics = languageService.doDiagnostics(document, () -> {
+		}, new XMLValidationSettings());
+		assertTrue(diagnostics.size() == 0); 
+	}
+	
+	@Test
+	public void testGoalDiagnosticsNoFalsePositives()
+			throws IOException, InterruptedException, ExecutionException, URISyntaxException {
+		DOMDocument document = createDOMDocument("/pom-plugin-valid-goal-diagnostic.xml", languageService);
 		assertTrue(languageService.doDiagnostics(document, () -> {
-		}, new XMLValidationSettings()).stream().map(Diagnostic::getMessage).anyMatch(message -> message.contains(
-				"Incomplete GAV")));
-		assertTrue(languageService.doDiagnostics(document, () -> {
-		}, new XMLValidationSettings()).size() == 2); 
+		}, new XMLValidationSettings()).size() == 0);
 	}
 
 	@Test

--- a/lemminx-maven/src/test/resources/pom-plugin-diagnostic-missing-groupid.xml
+++ b/lemminx-maven/src/test/resources/pom-plugin-diagnostic-missing-groupid.xml
@@ -1,0 +1,21 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">  <modelVersion>4.0.0</modelVersion>
+  <groupId>demo</groupId>
+  <artifactId>demo</artifactId>
+  <version>0.0.1-SNAPSHOT</version>
+  <build>
+    <plugins>
+      <plugin>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <version>3.8.1</version>
+        <configuration>
+          <release>14</release>
+          <compilerArgs>
+            <arg>--enable-preview</arg>
+          </compilerArgs>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/lemminx-maven/src/test/resources/pom-plugin-valid-goal-diagnostic.xml
+++ b/lemminx-maven/src/test/resources/pom-plugin-valid-goal-diagnostic.xml
@@ -1,0 +1,35 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+	<modelVersion>4.0.0</modelVersion>
+
+	<groupId>org.test</groupId>
+	<artifactId>test</artifactId>
+	<version>0.0.1-SNAPSHOT</version>
+	<packaging>pom</packaging>
+	
+	<build>
+		<plugins>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-enforcer-plugin</artifactId>
+				<version>3.0.0-M3</version>
+				<executions>
+					<execution>
+						<id>enforce-maven</id>
+						<goals>
+							<goal>enforce</goal>
+						</goals>
+						<configuration>
+							<rules>
+								<requireMavenVersion>
+									<version>3.0.5</version>
+								</requireMavenVersion>
+							</rules>
+						</configuration>
+					</execution>
+				</executions>
+			</plugin> 
+		</plugins>
+	</build>
+</project>


### PR DESCRIPTION
Reenable  goal diagnostics

Test false goal diagnostics (part of #48)

If the groupId of a plugin is missing but its artifactId is present,
search the projects plugins for it in order to resolve the plugin (part
of #74)

Fix #48
Fix #74
Signed-off-by: Andrew Obuchowicz <aobuchow@redhat.com>