### PR TITLE
Update to LemMinX 0.12.0

### DIFF
--- a/lemminx-maven/pom.xml
+++ b/lemminx-maven/pom.xml
@@ -31,7 +31,7 @@
 		<dependency>
 			<groupId>org.eclipse.lemminx</groupId>
 			<artifactId>org.eclipse.lemminx</artifactId>
-			<version>0.11.1</version>
+			<version>0.12.0</version>
 		</dependency>
 		<dependency>
 			<groupId>org.apache.maven</groupId>

--- a/lemminx-maven/src/main/java/org/eclipse/lemminx/maven/snippets/SnippetRegistry.java
+++ b/lemminx-maven/src/main/java/org/eclipse/lemminx/maven/snippets/SnippetRegistry.java
@@ -119,7 +119,7 @@ public class SnippetRegistry {
 			return contextFilter.test(s.getContext());
 		}).map(snippet -> {
 			String filter = snippet.getPrefix();
-			int startOffset = StringUtils.findExprBeforeAt(document.getText(), filter, completionOffset);
+			int startOffset = findExprBeforeAt(document.getText(), filter, completionOffset);
 			if (startOffset == -1) {
 				startOffset = completionOffset;
 			}
@@ -194,5 +194,31 @@ public class SnippetRegistry {
 			replaceStart = offset;
 		}
 		return new Range(document.positionAt(replaceStart), document.positionAt(replaceEnd));
+	}
+	
+	private static int findExprBeforeAt(String text, String expr, int offset) {
+		if (offset <= 0) {
+			return -1;
+		}
+		expr = expr.toUpperCase();
+		int startOffset = -1;
+		char first = expr.charAt(0);
+		int length = Math.min(offset, expr.length());
+		int i = 0;
+		for (i = 1; i <= length; i++) {
+			if (Character.toUpperCase(text.charAt(offset - i)) == first) {
+				startOffset = offset - i;
+				break;
+			}
+		}
+		if (startOffset == -1) {
+			return -1;
+		}
+		for (int j = 0; j < i; j++) {
+			if (Character.toUpperCase(text.charAt(startOffset + j)) != expr.charAt(j)) {
+				return -1;
+			}
+		}
+		return startOffset - 1;
 	}
 }

--- a/lemminx-maven/src/test/java/org/eclipse/lemminx/maven/test/LocalPluginTest.java
+++ b/lemminx-maven/src/test/java/org/eclipse/lemminx/maven/test/LocalPluginTest.java
@@ -23,7 +23,6 @@ import org.eclipse.lemminx.dom.DOMDocument;
 import org.eclipse.lemminx.extensions.contentmodel.settings.XMLValidationSettings;
 import org.eclipse.lemminx.services.XMLLanguageService;
 import org.eclipse.lemminx.settings.SharedSettings;
-import org.eclipse.lemminx.settings.XMLHoverSettings;
 import org.eclipse.lsp4j.CompletionItem;
 import org.eclipse.lsp4j.Diagnostic;
 import org.eclipse.lsp4j.Position;
@@ -102,27 +101,27 @@ public class LocalPluginTest {
 	@Test
  	public void testPluginConfigurationHover() throws IOException, InterruptedException, ExecutionException, URISyntaxException {
 		assertTrue(languageService.doHover(createDOMDocument("/pom-plugin-configuration-hover.xml", languageService),
-				new Position(15, 6), new XMLHoverSettings()).getContents().getRight().getValue().contains("cause a failure if there are no tests to run"));
+				new Position(15, 6), new SharedSettings()).getContents().getRight().getValue().contains("cause a failure if there are no tests to run"));
 	}
 	
 	@Test
  	public void testPluginNestedConfigurationHover() throws IOException, InterruptedException, ExecutionException, URISyntaxException {
 		//<compilerArguments> hover
 		String hoverContents = languageService.doHover(createDOMDocument("/pom-plugin-nested-configuration-hover.xml", languageService),
-				new Position(15, 8), new XMLHoverSettings()).getContents().getRight().getValue();
+				new Position(15, 8), new SharedSettings()).getContents().getRight().getValue();
 		assertTrue(hoverContents.contains("**Type:** List&lt;String&gt;"));
 		assertTrue(hoverContents.contains("Sets the arguments to be passed to the compiler"));
 		
 		//<arg> hover, child of compilerArguments
 		//Should have a different type, but sames description
 		hoverContents = languageService.doHover(createDOMDocument("/pom-plugin-nested-configuration-hover.xml", languageService),
-				new Position(16, 8), new XMLHoverSettings()).getContents().getRight().getValue();
+				new Position(16, 8), new SharedSettings()).getContents().getRight().getValue();
 		assertTrue(hoverContents.contains("**Type:** String"));
 		assertTrue(hoverContents.contains("Sets the arguments to be passed to the compiler"));
 		
 		//<annotationProcessorPath> hover
 		hoverContents = languageService.doHover(createDOMDocument("/pom-plugin-nested-configuration-hover.xml", languageService),
-				new Position(20, 9), new XMLHoverSettings()).getContents().getRight().getValue();
+				new Position(20, 9), new SharedSettings()).getContents().getRight().getValue();
 		//annotationProcessorPath type should be a DependencyCoordinate and its description should be that of annotationsProcessorPath
 		assertTrue(hoverContents.contains("org.apache.maven.plugin.compiler.DependencyCoordinate"));
 		assertTrue(hoverContents.contains("Classpath elements to supply as annotation processor path."));
@@ -130,7 +129,7 @@ public class LocalPluginTest {
 		
 		//<groupId> hover
 		hoverContents = languageService.doHover(createDOMDocument("/pom-plugin-nested-configuration-hover.xml", languageService),
-				new Position(21, 9), new XMLHoverSettings()).getContents().getRight().getValue();
+				new Position(21, 9), new SharedSettings()).getContents().getRight().getValue();
 		//GroupId type should be a string and its description should be that of annotationsProcessorPath
 		assertTrue(hoverContents.contains("**Type:** String"));
 		assertTrue(hoverContents.contains("Classpath elements to supply as annotation processor path."));
@@ -140,13 +139,13 @@ public class LocalPluginTest {
 	@Test
  	public void testPluginGoalHover() throws IOException, InterruptedException, ExecutionException, URISyntaxException {
 		assertTrue(languageService.doHover(createDOMDocument("/pom-plugin-goal-hover.xml", languageService),
-				new Position(18, 22), new XMLHoverSettings()).getContents().getRight().getValue().contains("Run tests using Surefire."));
+				new Position(18, 22), new SharedSettings()).getContents().getRight().getValue().contains("Run tests using Surefire."));
 	}
 	
 	@Test
  	public void testPluginArtifactHover() throws IOException, InterruptedException, ExecutionException, URISyntaxException, TimeoutException {
 		assertTrue(languageService.doHover(createDOMDocument("/pom-plugin-artifact-hover.xml", languageService),
-				new Position(14, 18), new XMLHoverSettings()).getContents().getRight().getValue().contains("Maven Surefire MOJO in maven-surefire-plugin"));
+				new Position(14, 18), new SharedSettings()).getContents().getRight().getValue().contains("Maven Surefire MOJO in maven-surefire-plugin"));
 	}
 	
 	// Diagnostic related tests

--- a/lemminx-maven/src/test/java/org/eclipse/lemminx/maven/test/PluginResolutionTest.java
+++ b/lemminx-maven/src/test/java/org/eclipse/lemminx/maven/test/PluginResolutionTest.java
@@ -20,7 +20,7 @@ import java.util.concurrent.ExecutionException;
 import org.apache.commons.io.FileUtils;
 import org.eclipse.lemminx.maven.MavenPlugin;
 import org.eclipse.lemminx.services.XMLLanguageService;
-import org.eclipse.lemminx.settings.XMLHoverSettings;
+import org.eclipse.lemminx.settings.SharedSettings;
 import org.eclipse.lsp4j.Position;
 import org.junit.After;
 import org.junit.Before;
@@ -69,7 +69,7 @@ public class PluginResolutionTest {
 		// <compilerArguments> hover
 		String hoverContents = languageService
 				.doHover(createDOMDocument("/pom-plugin-nested-configuration-hover.xml", languageService),
-						new Position(15, 8), new XMLHoverSettings())
+						new Position(15, 8), new SharedSettings())
 				.getContents().getRight().getValue();
 		assertTrue(hoverContents.contains("**Type:** List&lt;String&gt;"));
 		assertTrue(hoverContents.contains("Sets the arguments to be passed to the compiler"));

--- a/lemminx-maven/src/test/java/org/eclipse/lemminx/maven/test/RemoteRepositoryTest.java
+++ b/lemminx-maven/src/test/java/org/eclipse/lemminx/maven/test/RemoteRepositoryTest.java
@@ -19,7 +19,6 @@ import java.util.concurrent.ExecutionException;
 import org.eclipse.lemminx.dom.DOMDocument;
 import org.eclipse.lemminx.services.XMLLanguageService;
 import org.eclipse.lemminx.settings.SharedSettings;
-import org.eclipse.lemminx.settings.XMLHoverSettings;
 import org.eclipse.lsp4j.CompletionItem;
 import org.eclipse.lsp4j.Hover;
 import org.eclipse.lsp4j.MarkupContent;
@@ -83,7 +82,7 @@ public class RemoteRepositoryTest {
 		final Position position = new Position(14, 18);
  		Hover hover;
  		do {
- 	 		hover = languageService.doHover(document, position, new XMLHoverSettings());
+ 	 		hover = languageService.doHover(document, position, new SharedSettings());
  	 		Thread.sleep(500);
  		} while (!(((MarkupContent) hover.getContents().getRight()).getValue().contains(description)));
  		// if got out of the loop without timeout, then test is PASSED

--- a/lemminx-maven/src/test/java/org/eclipse/lemminx/maven/test/SimpleModelTest.java
+++ b/lemminx-maven/src/test/java/org/eclipse/lemminx/maven/test/SimpleModelTest.java
@@ -30,7 +30,6 @@ import org.eclipse.lemminx.extensions.contentmodel.settings.XMLValidationSetting
 import org.eclipse.lemminx.maven.DOMUtils;
 import org.eclipse.lemminx.services.XMLLanguageService;
 import org.eclipse.lemminx.settings.SharedSettings;
-import org.eclipse.lemminx.settings.XMLHoverSettings;
 import org.eclipse.lemminx.utils.XMLPositionUtility;
 import org.eclipse.lsp4j.CompletionItem;
 import org.eclipse.lsp4j.CompletionList;
@@ -138,13 +137,13 @@ public class SimpleModelTest {
 	@Test
  	public void testPropertyHover() throws IOException, InterruptedException, ExecutionException, URISyntaxException {
 		DOMDocument document = createDOMDocument("/pom-with-properties.xml", languageService);
-		Hover hover = languageService.doHover(document, new Position(15, 20), new XMLHoverSettings());
+		Hover hover = languageService.doHover(document, new Position(15, 20), new SharedSettings());
  		assertTrue((((MarkupContent) hover.getContents().getRight()).getValue().contains("$")));
 
- 		hover = languageService.doHover(document, new Position(15, 35), new XMLHoverSettings());
+ 		hover = languageService.doHover(document, new Position(15, 35), new SharedSettings());
  		assertTrue((((MarkupContent) hover.getContents().getRight()).getValue().contains("0.0.1-SNAPSHOT")));
 
- 		hover = languageService.doHover(document, new Position(15, 13), new XMLHoverSettings());
+ 		hover = languageService.doHover(document, new Position(15, 13), new SharedSettings());
  		assertNull(hover);
 	}
 	


### PR DESCRIPTION
StringUtils.findExpreBeforeAt was removed from LemMinX so it was moved
to SnippetRegistry.

Fix #92

Signed-off-by: Andrew Obuchowicz <aobuchow@redhat.com>