### PR TITLE
Maven property hovers should MarkupContent use "markdown" kind

### DIFF
--- a/lemminx-maven/src/main/java/org/eclipse/lemminx/maven/MavenHoverParticipant.java
+++ b/lemminx-maven/src/main/java/org/eclipse/lemminx/maven/MavenHoverParticipant.java
@@ -327,7 +327,7 @@ public class MavenHoverParticipant implements IHoverParticipant {
 			for (Entry<String, String> prop : allProps.entrySet()) {
 				String mavenProperty = prop.getKey();
 				if (property.equals(mavenProperty)) {
-					return new Hover(new MarkupContent("plaintext", "Property: " + mavenProperty
+					return new Hover(new MarkupContent("markdown", "Property: " + mavenProperty
 							+ MavenPluginUtils.LINE_BREAK + "Value: " + prop.getValue() + MavenPluginUtils.LINE_BREAK));
 				}
 			}


### PR DESCRIPTION
Part of #97

Signed-off-by: Andrew Obuchowicz <aobuchow@redhat.com>