### PR TITLE
Only use Markdown formatting when client supports it

### DIFF
--- a/lemminx-maven/src/main/java/org/eclipse/lemminx/maven/MarkdownUtils.java
+++ b/lemminx-maven/src/main/java/org/eclipse/lemminx/maven/MarkdownUtils.java
@@ -1,0 +1,46 @@
+/*******************************************************************************
+ * Copyright (c) 2020 Red Hat Inc. and others.
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+package org.eclipse.lemminx.maven;
+
+public class MarkdownUtils {
+	public static final String LINE_BREAK = "\n\n";
+
+	private MarkdownUtils() {}
+	
+	public static String getLineBreak(boolean supportsMarkdown) {
+		return supportsMarkdown ? MarkdownUtils.LINE_BREAK : "\n";
+	}
+	
+	public static String toBold(String message) {
+		StringBuilder bold = new StringBuilder();
+
+		bold.append("**");
+		bold.append(message.trim());
+		bold.append("**");
+		
+		if (message.endsWith(" ")) {
+			bold.append(" ");
+		}
+		
+		return bold.toString();
+	}
+
+	public static String htmlXMLToMarkdown(String description) {
+		if (description.contains("<pre>") && description.contains("&lt;")) {
+			//Add markdown formatting to XML
+			String xmlContent = description.substring(description.indexOf("<pre>") + 6, description.indexOf("</pre>") - 1);
+			description = description.substring(0, description.indexOf("<pre>"));
+			xmlContent = xmlContent.replaceAll("&lt;", "<");
+			xmlContent = xmlContent.replaceAll("&gt;", ">");
+			xmlContent = "```XML" + "\n" + xmlContent + "\n" + "```";
+			description = description + LINE_BREAK + xmlContent;
+		}
+		return description;
+	}
+}

--- a/lemminx-maven/src/main/java/org/eclipse/lemminx/maven/MavenCompletionParticipant.java
+++ b/lemminx-maven/src/main/java/org/eclipse/lemminx/maven/MavenCompletionParticipant.java
@@ -69,6 +69,7 @@ import org.eclipse.lsp4j.CompletionItem;
 import org.eclipse.lsp4j.CompletionItemKind;
 import org.eclipse.lsp4j.InsertTextFormat;
 import org.eclipse.lsp4j.MarkupContent;
+import org.eclipse.lsp4j.MarkupKind;
 import org.eclipse.lsp4j.Position;
 import org.eclipse.lsp4j.Range;
 import org.eclipse.lsp4j.TextEdit;
@@ -122,9 +123,10 @@ public class MavenCompletionParticipant extends CompletionParticipantAdapter {
 			  return;
 		}
 		
+		boolean supportsMarkdown = request.canSupportMarkupKind(MarkupKind.MARKDOWN);
 		if ("configuration".equals(request.getParentElement().getLocalName())) {
 			MavenPluginUtils.collectPluginConfigurationParameters(request, cache, repoSession, pluginManager, buildPluginManager, mavenSession).stream()
-					.map(parameter -> toTag(parameter.getName(), MavenPluginUtils.getMarkupDescription(parameter), request))
+					.map(parameter -> toTag(parameter.getName(), MavenPluginUtils.getMarkupDescription(parameter, supportsMarkdown), request))
 					.forEach(response::addCompletionItem);
 		}
 	}

--- a/lemminx-maven/src/main/java/org/eclipse/lemminx/maven/PluginValidator.java
+++ b/lemminx-maven/src/main/java/org/eclipse/lemminx/maven/PluginValidator.java
@@ -61,7 +61,7 @@ public class PluginValidator {
 						diagnosticRequest.getXMLDocument());
 				diagnostics.add(artifactDiagnosticReq.createDiagnostic(
 						"Plugin could not be resolved. Ensure the plugin's groupId, artifactId and version are present."
-								+ MavenPluginUtils.LINE_BREAK + "Additional information: " + errorMessage,
+								+ MarkdownUtils.LINE_BREAK + "Additional information: " + errorMessage,
 						DiagnosticSeverity.Warning));
 			});
 			if (!diagnostics.isEmpty()) {

--- a/lemminx-maven/src/test/java/org/eclipse/lemminx/maven/test/LocalPluginTest.java
+++ b/lemminx-maven/src/test/java/org/eclipse/lemminx/maven/test/LocalPluginTest.java
@@ -14,6 +14,7 @@ import static org.junit.Assert.assertTrue;
 
 import java.io.IOException;
 import java.net.URISyntaxException;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.ExecutionException;
@@ -25,6 +26,8 @@ import org.eclipse.lemminx.services.XMLLanguageService;
 import org.eclipse.lemminx.settings.SharedSettings;
 import org.eclipse.lsp4j.CompletionItem;
 import org.eclipse.lsp4j.Diagnostic;
+import org.eclipse.lsp4j.HoverCapabilities;
+import org.eclipse.lsp4j.MarkupKind;
 import org.eclipse.lsp4j.Position;
 import org.eclipse.lsp4j.TextEdit;
 import org.junit.After;
@@ -37,6 +40,17 @@ public class LocalPluginTest {
 	@Rule public NoMavenCentralIndexTestRule rule = new NoMavenCentralIndexTestRule();
 
 	private XMLLanguageService languageService;
+	
+	private SharedSettings getMarkdownSharedSettings () {
+		SharedSettings settings = new SharedSettings();
+		HoverCapabilities hover = new HoverCapabilities();
+		String capabilities[] = { MarkupKind.MARKDOWN };
+		hover.setContentFormat(Arrays.asList(capabilities));
+		
+		settings.getHoverSettings().setCapabilities(hover);
+		
+		return settings;
+	}
 
 	@Before
 	public void setUp() throws IOException {
@@ -118,20 +132,20 @@ public class LocalPluginTest {
  	public void testPluginNestedConfigurationHover() throws IOException, InterruptedException, ExecutionException, URISyntaxException {
 		//<compilerArguments> hover
 		String hoverContents = languageService.doHover(createDOMDocument("/pom-plugin-nested-configuration-hover.xml", languageService),
-				new Position(15, 8), new SharedSettings()).getContents().getRight().getValue();
+				new Position(15, 8), getMarkdownSharedSettings()).getContents().getRight().getValue();
 		assertTrue(hoverContents.contains("**Type:** List&lt;String&gt;"));
 		assertTrue(hoverContents.contains("Sets the arguments to be passed to the compiler"));
 		
 		//<arg> hover, child of compilerArguments
 		//Should have a different type, but sames description
 		hoverContents = languageService.doHover(createDOMDocument("/pom-plugin-nested-configuration-hover.xml", languageService),
-				new Position(16, 8), new SharedSettings()).getContents().getRight().getValue();
+				new Position(16, 8), getMarkdownSharedSettings()).getContents().getRight().getValue();
 		assertTrue(hoverContents.contains("**Type:** String"));
 		assertTrue(hoverContents.contains("Sets the arguments to be passed to the compiler"));
 		
 		//<annotationProcessorPath> hover
 		hoverContents = languageService.doHover(createDOMDocument("/pom-plugin-nested-configuration-hover.xml", languageService),
-				new Position(20, 9), new SharedSettings()).getContents().getRight().getValue();
+				new Position(20, 9), getMarkdownSharedSettings()).getContents().getRight().getValue();
 		//annotationProcessorPath type should be a DependencyCoordinate and its description should be that of annotationsProcessorPath
 		assertTrue(hoverContents.contains("org.apache.maven.plugin.compiler.DependencyCoordinate"));
 		assertTrue(hoverContents.contains("Classpath elements to supply as annotation processor path."));
@@ -139,7 +153,7 @@ public class LocalPluginTest {
 		
 		//<groupId> hover
 		hoverContents = languageService.doHover(createDOMDocument("/pom-plugin-nested-configuration-hover.xml", languageService),
-				new Position(21, 9), new SharedSettings()).getContents().getRight().getValue();
+				new Position(21, 9), getMarkdownSharedSettings()).getContents().getRight().getValue();
 		//GroupId type should be a string and its description should be that of annotationsProcessorPath
 		assertTrue(hoverContents.contains("**Type:** String"));
 		assertTrue(hoverContents.contains("Classpath elements to supply as annotation processor path."));

--- a/lemminx-maven/src/test/java/org/eclipse/lemminx/maven/test/PluginResolutionTest.java
+++ b/lemminx-maven/src/test/java/org/eclipse/lemminx/maven/test/PluginResolutionTest.java
@@ -15,12 +15,16 @@ import static org.junit.Assert.assertTrue;
 import java.io.File;
 import java.io.IOException;
 import java.net.URISyntaxException;
+import java.util.Arrays;
+import java.util.List;
 import java.util.concurrent.ExecutionException;
 
 import org.apache.commons.io.FileUtils;
 import org.eclipse.lemminx.maven.MavenPlugin;
 import org.eclipse.lemminx.services.XMLLanguageService;
 import org.eclipse.lemminx.settings.SharedSettings;
+import org.eclipse.lsp4j.HoverCapabilities;
+import org.eclipse.lsp4j.MarkupKind;
 import org.eclipse.lsp4j.Position;
 import org.junit.After;
 import org.junit.Before;
@@ -67,9 +71,17 @@ public class PluginResolutionTest {
 			throws IOException, InterruptedException, ExecutionException, URISyntaxException {
 		assertFalse(initialMavenPluginApiDirectory.exists());
 		// <compilerArguments> hover
+		
+		SharedSettings settings = new SharedSettings();
+		HoverCapabilities hover = new HoverCapabilities();
+		String capabilities[] = { MarkupKind.MARKDOWN };
+		hover.setContentFormat(Arrays.asList(capabilities));
+		
+		settings.getHoverSettings().setCapabilities(hover);
+		
 		String hoverContents = languageService
 				.doHover(createDOMDocument("/pom-plugin-nested-configuration-hover.xml", languageService),
-						new Position(15, 8), new SharedSettings())
+						new Position(15, 8), settings)
 				.getContents().getRight().getValue();
 		assertTrue(hoverContents.contains("**Type:** List&lt;String&gt;"));
 		assertTrue(hoverContents.contains("Sets the arguments to be passed to the compiler"));


### PR DESCRIPTION
- Added a convertToBold function in MavenPluginUtils that allows for formatting based on if the hover request supports markdown. 
- Returned MarkupContent now has the correct MarkupKind 
- Added null checks/blank string checks to make hover clearer and no more 'null' strings