### PR TITLE
Fixed FileCompletionItem to replace the entire node value for cleaner completion

### DIFF
--- a/lemminx-maven/src/test/java/org/eclipse/lemminx/maven/test/LocalPluginTest.java
+++ b/lemminx-maven/src/test/java/org/eclipse/lemminx/maven/test/LocalPluginTest.java
@@ -29,6 +29,7 @@ import org.eclipse.lsp4j.Diagnostic;
 import org.eclipse.lsp4j.HoverCapabilities;
 import org.eclipse.lsp4j.MarkupKind;
 import org.eclipse.lsp4j.Position;
+import org.eclipse.lsp4j.Range;
 import org.eclipse.lsp4j.TextEdit;
 import org.junit.After;
 import org.junit.Before;
@@ -118,6 +119,19 @@ public class LocalPluginTest {
 				pos, new SharedSettings())
 			.getItems();
 		assertTrue(completions.stream().map(CompletionItem::getLabel).anyMatch("release"::equals));
+	}
+	
+	// Test related to https://github.com/eclipse/lemminx-maven/issues/114
+	@Test
+	public void testFileCompletionDuplicatePrefix() throws IOException, URISyntaxException {
+		Position pos = new Position(11, 26);
+		List<CompletionItem> completions = languageService.doComplete(createDOMDocument("/pom-complete-file-path.xml", languageService),
+				pos, new SharedSettings())
+			.getItems();
+		// Expected replace range is the whole text node range
+		Range expectedReplaceRange = new Range(new Position(11, 10), new Position(11, 26));
+		
+		assertTrue(completions.stream().map(item -> item.getTextEdit().getRange()).anyMatch(expectedReplaceRange::equals));
 	}
 	
 	// Hover related tests

--- a/lemminx-maven/src/test/resources/pom-complete-file-path.xml
+++ b/lemminx-maven/src/test/resources/pom-complete-file-path.xml
@@ -1,0 +1,14 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+	<modelVersion>4.0.0</modelVersion>
+	
+	<groupId>org.test</groupId>
+	<artifactId>test</artifactId>
+	<version>0.0.1-SNAPSHOT</version>
+	<packaging>pom</packaging>
+	
+	<modules>
+		<module>multi-module/fol</module>
+	</modules>
+</project>


### PR DESCRIPTION
- Changed how we got the prefix for autocompletion, no longer need to do substring of the entire document. 
- toFileCompletionItem will now attempt to get the full range of the node value, and replace the entire value rather than what is returned by request.getReplaceRange