### PR TITLE
Issue #133 - Only load Plexus and Maven when necessary

### DIFF
--- a/lemminx-maven/src/main/java/org/eclipse/lemminx/maven/MavenDefinitionParticipant.java
+++ b/lemminx-maven/src/main/java/org/eclipse/lemminx/maven/MavenDefinitionParticipant.java
@@ -22,7 +22,6 @@ import org.apache.maven.project.MavenProject;
 import org.eclipse.lemminx.dom.DOMDocument;
 import org.eclipse.lemminx.dom.DOMElement;
 import org.eclipse.lemminx.dom.DOMNode;
-import org.eclipse.lemminx.maven.searcher.LocalRepositorySearcher;
 import org.eclipse.lemminx.services.extensions.IDefinitionParticipant;
 import org.eclipse.lemminx.services.extensions.IDefinitionRequest;
 import org.eclipse.lemminx.utils.XMLPositionUtility;
@@ -33,12 +32,10 @@ import org.eclipse.lsp4j.jsonrpc.CancelChecker;
 
 public class MavenDefinitionParticipant implements IDefinitionParticipant {
 
-	private LocalRepositorySearcher localRepositorySearcher;
-	private MavenProjectCache cache;
+	private final MavenLemminxExtension plugin;
 
-	public MavenDefinitionParticipant(MavenProjectCache cache, LocalRepositorySearcher localRepositorySearcher) {
-		this.cache = cache;
-		this.localRepositorySearcher = localRepositorySearcher;
+	public MavenDefinitionParticipant(MavenLemminxExtension plugin) {
+		this.plugin = plugin;
 	}
 	
 	@Override
@@ -100,7 +97,7 @@ public class MavenDefinitionParticipant implements IDefinitionParticipant {
 			return null; 
 		}
 		DOMDocument xmlDocument = request.getXMLDocument();
-		MavenProject project = cache.getLastSuccessfulMavenProject(xmlDocument);
+		MavenProject project = plugin.getProjectCache().getLastSuccessfulMavenProject(xmlDocument);
 		if (project == null) {
 			return null;
 		}
@@ -130,7 +127,7 @@ public class MavenDefinitionParticipant implements IDefinitionParticipant {
 	}
 
 	private boolean match(File relativeFile, Dependency dependency) {
-		MavenProject p = cache.getSnapshotProject(relativeFile).get();
+		MavenProject p = plugin.getProjectCache().getSnapshotProject(relativeFile).get();
 		return p != null &&
 				p.getGroupId().equals(dependency.getGroupId()) &&
 				p.getArtifactId().equals(dependency.getArtifactId()) &&
@@ -138,7 +135,7 @@ public class MavenDefinitionParticipant implements IDefinitionParticipant {
 	}
 
 	private File getArtifactLocation(Dependency dependency) {
-		File localArtifact = localRepositorySearcher.findLocalFile(dependency);
+		File localArtifact = plugin.getLocalRepositorySearcher().findLocalFile(dependency);
 		if (localArtifact != null) {
 			return localArtifact;
 		}

--- a/lemminx-maven/src/main/java/org/eclipse/lemminx/maven/PluginValidator.java
+++ b/lemminx-maven/src/main/java/org/eclipse/lemminx/maven/PluginValidator.java
@@ -29,24 +29,16 @@ import org.eclipse.lsp4j.Diagnostic;
 import org.eclipse.lsp4j.DiagnosticSeverity;
 
 public class PluginValidator {
-	private final MavenProjectCache cache;
-	private final MavenPluginManager pluginManager;
-	private final RepositorySystemSession repoSession;
-	private final MavenSession mavenSession;
-	private final BuildPluginManager buildPluginManager;
 
-	public PluginValidator(MavenProjectCache cache, RepositorySystemSession repoSession, MavenSession mavenSession,
-			MavenPluginManager pluginManager, BuildPluginManager buildPluginManager) {
-		this.cache = cache;
-		this.repoSession = repoSession;
-		this.pluginManager = pluginManager;
-		this.mavenSession = mavenSession;
-		this.buildPluginManager = buildPluginManager;
+	private MavenLemminxExtension plugin;
+
+	public PluginValidator(MavenLemminxExtension plugin) {
+		this.plugin = plugin;
 	}
 
 	public Optional<List<Diagnostic>> validatePluginResolution(DiagnosticRequest diagnosticRequest) {
 		try {
-			MavenPluginUtils.getContainingPluginDescriptor(diagnosticRequest, cache, repoSession, pluginManager);
+			MavenPluginUtils.getContainingPluginDescriptor(diagnosticRequest, plugin);
 		} catch (PluginResolutionException | PluginDescriptorParsingException | InvalidPluginDescriptorException e) {
 			e.printStackTrace();
 			
@@ -83,8 +75,7 @@ public class PluginValidator {
 
 		Set<Parameter> parameters = new HashSet<Parameter>();
 		try {
-			parameters = MavenPluginUtils.collectPluginConfigurationParameters(diagnosticRequest, cache, repoSession,
-					pluginManager, buildPluginManager, mavenSession);
+			parameters = MavenPluginUtils.collectPluginConfigurationParameters(diagnosticRequest, plugin);
 		} catch (PluginResolutionException | PluginDescriptorParsingException | InvalidPluginDescriptorException e) {
 			e.printStackTrace();
 			// A diagnostic was already added in validatePluginResolution()
@@ -118,8 +109,7 @@ public class PluginValidator {
 		if (node.isElement() && node.hasChildNodes()) {
 			PluginDescriptor pluginDescriptor;
 			try {
-				pluginDescriptor = MavenPluginUtils.getContainingPluginDescriptor(diagnosticRequest, cache, repoSession,
-						pluginManager);
+				pluginDescriptor = MavenPluginUtils.getContainingPluginDescriptor(diagnosticRequest, plugin);
 				if (pluginDescriptor != null) {
 					internalValidateGoal(diagnosticRequest, pluginDescriptor).ifPresent(diagnostics::add);;					
 				}

--- a/lemminx-maven/src/test/java/org/eclipse/lemminx/maven/test/MavenProjectCacheTest.java
+++ b/lemminx-maven/src/test/java/org/eclipse/lemminx/maven/test/MavenProjectCacheTest.java
@@ -36,7 +36,6 @@ public class MavenProjectCacheTest {
 		String content = FileUtils.readFileToString(new File(uri), "UTF-8");
 		DOMDocument doc = new DOMDocument(new TextDocument(content, uri.toString()), null);
 		MavenLemminxExtension plugin = new MavenLemminxExtension();
-		plugin.initialize(null);
 		MavenProjectCache cache = plugin.getProjectCache();
 		MavenProject project = cache.getLastSuccessfulMavenProject(doc);
 		assertNotNull(project);
@@ -49,7 +48,6 @@ public class MavenProjectCacheTest {
 		String content = FileUtils.readFileToString(pomFile, "UTF-8");
 		DOMDocument doc = new DOMDocument(new TextDocument(content, uri.toString()), null);
 		MavenLemminxExtension plugin = new MavenLemminxExtension();
-		plugin.initialize(null);
 		MavenProjectCache cache = plugin.getProjectCache();
 		MavenProject project = cache.getLastSuccessfulMavenProject(doc);
 		assertNotNull(project);
@@ -59,7 +57,6 @@ public class MavenProjectCacheTest {
 	public void testParentChangeReflectedToChild()
 			throws IOException, InterruptedException, ExecutionException, URISyntaxException, Exception {
 		MavenLemminxExtension plugin = new MavenLemminxExtension();
-		plugin.initialize(null);
 		MavenProjectCache cache = plugin.getProjectCache();
 		DOMDocument doc = getDocument("/pom-with-properties-in-parent.xml");
 		MavenProject project = cache.getLastSuccessfulMavenProject(doc);


### PR DESCRIPTION
Do not load Plexus/Maven on extension start, but delay it to load the
extension on demand.

Signed-off-by: Mickael Istria <mistria@redhat.com>