### PR TITLE
Issue #134 - Don't use System.out, System.err or e.printStackTrace

### DIFF
--- a/lemminx-maven/src/main/java/org/eclipse/lemminx/maven/MavenLemminxExtension.java
+++ b/lemminx-maven/src/main/java/org/eclipse/lemminx/maven/MavenLemminxExtension.java
@@ -16,6 +16,8 @@ import java.net.URI;
 import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 
 import org.apache.maven.Maven;
 import org.apache.maven.artifact.repository.ArtifactRepository;
@@ -63,6 +65,7 @@ import com.google.gson.JsonObject;
  */
 public class MavenLemminxExtension implements IXMLExtension {
 
+	private static final Logger LOGGER = Logger.getLogger(MavenLemminxExtension.class.getName());
 	private static final String MAVEN_XMLLS_EXTENSION_REALM_ID = MavenLemminxExtension.class.getName();
 
 	private XMLExtensionsRegistry currentRegistry;
@@ -111,7 +114,7 @@ public class MavenLemminxExtension implements IXMLExtension {
 			definitionParticipant = new MavenDefinitionParticipant(this);
 			registry.registerDefinitionParticipant(definitionParticipant);
 		} catch (Exception ex) {
-			ex.printStackTrace();
+			LOGGER.log(Level.SEVERE, ex.getCause().toString(), ex);
 		}
 	}
 
@@ -140,7 +143,7 @@ public class MavenLemminxExtension implements IXMLExtension {
 			mavenPluginManager = container.lookup(MavenPluginManager.class);
 			buildPluginManager = container.lookup(BuildPluginManager.class);
 		} catch (Exception e) {
-			e.printStackTrace();
+			LOGGER.log(Level.SEVERE, e.getCause().toString(), e);
 			stop(currentRegistry);
 		}
 	}
@@ -266,7 +269,7 @@ public class MavenLemminxExtension implements IXMLExtension {
 					|| file.getName().endsWith(Maven.POMv4);
 		} catch (Exception ex) {
 			// usually because of not so tolerant Java URI API
-			ex.printStackTrace();
+			LOGGER.log(Level.SEVERE, ex.getMessage(), ex);
 			return false;
 		}
 	}

--- a/lemminx-maven/src/main/java/org/eclipse/lemminx/maven/MavenParseUtils.java
+++ b/lemminx-maven/src/main/java/org/eclipse/lemminx/maven/MavenParseUtils.java
@@ -12,7 +12,12 @@ import org.apache.maven.model.Dependency;
 import org.eclipse.lemminx.dom.DOMElement;
 import org.eclipse.lemminx.dom.DOMNode;
 
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
 public class MavenParseUtils {
+
+	private static final Logger LOGGER = Logger.getLogger(MavenParseUtils.class.getName());
 
 	public static Dependency parseArtifact(DOMNode node) {
 		if (node == null) {
@@ -40,41 +45,40 @@ public class MavenParseUtils {
 					if (value == null) {
 						continue;
 					}
-					value = value.trim(); 
+					value = value.trim();
 					switch (tag.getLocalName()) {
-					case "groupId":
-						res.setGroupId(value);
-						break;
-					case "artifactId":
-						res.setArtifactId(value);
-						break;
-					case "version":
-						res.setVersion(value);
-						break;
-					case "scope":
-						res.setScope(value);
-						break;
-					case "type":
-						res.setType(value);
-						break;
-					case "classifier":
-						res.setClassifier(value);
-						break;
+						case "groupId":
+							res.setGroupId(value);
+							break;
+						case "artifactId":
+							res.setArtifactId(value);
+							break;
+						case "version":
+							res.setVersion(value);
+							break;
+						case "scope":
+							res.setScope(value);
+							break;
+						case "type":
+							res.setType(value);
+							break;
+						case "classifier":
+							res.setClassifier(value);
+							break;
 					}
 				}
 			}
 		} catch (Exception e) {
-			e.printStackTrace();
-			System.out.println("Error parsing Artifact");
+			LOGGER.log(Level.SEVERE,"Error parsing Artifact", e);
 		}
 		return isEmpty(res) ? null : res;
 	}
 
 	private static boolean isEmpty(Dependency res) {
 		return res.getGroupId() == null &&
-			res.getArtifactId() == null &&
-			res.getVersion() == null &&
-			res.getScope() == null &&
-			res.getClassifier() == null;
+				res.getArtifactId() == null &&
+				res.getVersion() == null &&
+				res.getScope() == null &&
+				res.getClassifier() == null;
 	}
 }

--- a/lemminx-maven/src/main/java/org/eclipse/lemminx/maven/MavenProjectCache.java
+++ b/lemminx-maven/src/main/java/org/eclipse/lemminx/maven/MavenProjectCache.java
@@ -21,6 +21,8 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.Properties;
 import java.util.function.Consumer;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 import java.util.stream.Collectors;
 
 import org.apache.maven.artifact.repository.ArtifactRepositoryPolicy;
@@ -51,6 +53,8 @@ import org.eclipse.lemminx.dom.DOMDocument;
 
 public class MavenProjectCache {
 
+	private static final Logger LOGGER = Logger.getLogger(MavenProjectCache.class.getName());
+
 	private final Map<URI, Integer> lastCheckedVersion;
 	private final Map<URI, MavenProject> projectCache;
 	private final Map<URI, Collection<ModelProblem>> problemCache;
@@ -58,7 +62,7 @@ public class MavenProjectCache {
 	private final MavenLemminxExtension lemminxMavenPlugin;
 	private final PlexusContainer plexusContainer;
 	private final MavenExecutionRequest mavenRequest;
-	
+
 	MavenXpp3Reader mavenReader = new MavenXpp3Reader();
 	private ProjectBuilder projectBuilder;
 
@@ -79,7 +83,7 @@ public class MavenProjectCache {
 	}
 
 	/**
-	 * 
+	 *
 	 * @param document
 	 * @return the last MavenDocument that could be build for the more recent
 	 *         version of the provided document. If document fails to build a
@@ -92,7 +96,7 @@ public class MavenProjectCache {
 	}
 
 	/**
-	 * 
+	 *
 	 * @param document
 	 * @return the problems for the latest version of the document (either in cache,
 	 *         or the one passed in arguments)
@@ -170,7 +174,7 @@ public class MavenProjectCache {
 						projectCache.put(uri, project);
 						projectParsedListeners.forEach(listener -> listener.accept(project));
 					} catch (IOException | XmlPullParserException e1) {
-						e1.printStackTrace();
+						LOGGER.log(Level.SEVERE, e1.getMessage(), e1);
 					}
 				} else {
 					problems.add(
@@ -189,7 +193,7 @@ public class MavenProjectCache {
 			}
 		} catch (Exception e) {
 			// TODO Auto-generated catch block
-			e.printStackTrace();
+			LOGGER.log(Level.SEVERE, e.getCause().toString(), e);
 		}
 
 		lastCheckedVersion.put(uri, document.getTextDocument().getVersion());
@@ -216,7 +220,7 @@ public class MavenProjectCache {
 			projectBuilder = getPlexusContainer().lookup(ProjectBuilder.class);
 			System.setProperty(DefaultProjectBuilder.DISABLE_GLOBAL_MODEL_CACHE_SYSTEM_PROPERTY, Boolean.toString(true));
 		} catch (ComponentLookupException e) {
-			e.printStackTrace();
+			LOGGER.log(Level.SEVERE, e.getCause().toString(), e);
 		}
 	}
 

--- a/lemminx-maven/src/main/java/org/eclipse/lemminx/maven/PlexusConfigHelper.java
+++ b/lemminx-maven/src/main/java/org/eclipse/lemminx/maven/PlexusConfigHelper.java
@@ -32,6 +32,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.Properties;
 import java.util.Set;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 
 import org.apache.maven.execution.MavenSession;
 import org.apache.maven.plugin.BuildPluginManager;
@@ -51,13 +53,15 @@ import com.google.common.reflect.ClassPath.ClassInfo;
  * discovering how a PlexusConfiguration can be applied to an arbitrary object
  * tree. This class was copied from m2e's
  * org.eclipse.m2e.editor.mojo.PlexusConfigHelper
- * 
+ *
  * @see org.codehaus.plexus.component.configurator.BasicComponentConfigurator
  * @see org.codehaus.plexus.component.configurator.converters.lookup.DefaultConverterLookup
  * @see org.codehaus.plexus.component.configurator.converters.composite.ObjectWithFieldsConverter
  */
 public class PlexusConfigHelper {
 	// TODO: Rename this class maybe?
+
+	private static final Logger LOGGER = Logger.getLogger(PlexusConfigHelper.class.getName());
 
 	// TODO: Maybe using a static variable is bug prone? Although this variable is
 	// the only "state" held by this class
@@ -134,7 +138,7 @@ public class PlexusConfigHelper {
 	}
 
 	public static MojoParameter configure(MojoParameter p, boolean required, String expression, String description,
-			String defaultValue) {
+										  String defaultValue) {
 		p.setRequired(required);
 		p.setExpression(expression);
 		p.setDescription(description);
@@ -211,7 +215,7 @@ public class PlexusConfigHelper {
 			try {
 				cp = ClassPath.from(realm);
 			} catch (IOException e) {
-				e.printStackTrace();
+				LOGGER.log(Level.SEVERE, e.getCause().toString(), e);
 				return Collections.singletonList(enclosingClass);
 			}
 
@@ -220,7 +224,7 @@ public class PlexusConfigHelper {
 				try {
 					clazz = realm.loadClass(ci.getName());
 				} catch (ClassNotFoundException e) {
-					e.printStackTrace();
+					LOGGER.log(Level.SEVERE, e.getCause().toString(), e);
 					continue;
 				}
 
@@ -257,7 +261,7 @@ public class PlexusConfigHelper {
 		if (parameters == null) {
 			parameters = new ArrayList<>();
 			processedClasses.put(paramClass, parameters);
-			
+
 			Map<String, Type> properties = getClassProperties(paramClass);
 			for (Map.Entry<String, Type> e : properties.entrySet()) {
 				addParameter(realm, paramClass, e.getValue(), e.getKey(), null, parameters, false, null, null, null);
@@ -268,7 +272,7 @@ public class PlexusConfigHelper {
 	}
 
 	public static List<MojoParameter> getItemParameters(ClassRealm realm, Class<?> enclosingClass, String name,
-			Type paramType) {
+														Type paramType) {
 
 		Class<?> paramClass = getRawType(paramType);
 
@@ -314,8 +318,8 @@ public class PlexusConfigHelper {
 	}
 
 	public static void addParameter(ClassRealm realm, Class<?> enclosingClass, Type paramType, String name,
-			String alias, List<MojoParameter> parameters, boolean required, String expression, String description,
-			String defaultValue) {
+									String alias, List<MojoParameter> parameters, boolean required, String expression, String description,
+									String defaultValue) {
 
 		Class<?> paramClass = getRawType(paramType);
 		if (paramClass == null) {
@@ -393,7 +397,7 @@ public class PlexusConfigHelper {
 	}
 
 	public static List<MojoParameter> loadMojoParameters(PluginDescriptor descriptor, MojoDescriptor mojo,
-			MavenSession mavenSession, BuildPluginManager buildPluginManager) {
+														 MavenSession mavenSession, BuildPluginManager buildPluginManager) {
 		Class<?> clazz;
 		try {
 			clazz = mojo.getImplementationClass();
@@ -407,7 +411,7 @@ public class PlexusConfigHelper {
 			}
 		} catch (ClassNotFoundException | TypeNotPresentException | PluginResolutionException
 				| PluginManagerException ex) {
-			ex.printStackTrace();
+			LOGGER.log(Level.WARNING, ex.getCause().toString(), ex);
 			return Collections.emptyList();
 		}
 

--- a/lemminx-maven/src/main/java/org/eclipse/lemminx/maven/VersionValidator.java
+++ b/lemminx-maven/src/main/java/org/eclipse/lemminx/maven/VersionValidator.java
@@ -11,6 +11,8 @@ package org.eclipse.lemminx.maven;
 import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 
 import org.apache.maven.artifact.Artifact;
 import org.apache.maven.artifact.DefaultArtifact;
@@ -22,18 +24,20 @@ import org.eclipse.lsp4j.DiagnosticSeverity;
 
 public class VersionValidator {
 
+	private static final Logger LOGGER = Logger.getLogger(VersionValidator.class.getName());
+
 	public static Optional<List<Diagnostic>> validateVersion(DiagnosticRequest diagnosticRequest) {
 		DOMNode node = diagnosticRequest.getNode();
 		Dependency model = MavenParseUtils.parseArtifact(node);
 		Artifact artifact = null;
 		try {
-			 artifact = new DefaultArtifact(model.getGroupId(), model.getArtifactId(), model.getVersion(), model.getScope(), model.getType(), model.getClassifier(), new DefaultArtifactHandler(model.getType()));
+			artifact = new DefaultArtifact(model.getGroupId(), model.getArtifactId(), model.getVersion(), model.getScope(), model.getType(), model.getClassifier(), new DefaultArtifactHandler(model.getType()));
 			if (!artifact.isSelectedVersionKnown()) {
 				return Optional.of(Collections
 						.singletonList(diagnosticRequest.createDiagnostic("Version Error", DiagnosticSeverity.Error)));
 			}
 		} catch (Exception e) {
-			e.printStackTrace();
+			LOGGER.log(Level.SEVERE, e.getCause().toString(), e);
 		}
 		return Optional.empty();
 	}

--- a/lemminx-maven/src/main/java/org/eclipse/lemminx/maven/searcher/LocalRepositorySearcher.java
+++ b/lemminx-maven/src/main/java/org/eclipse/lemminx/maven/searcher/LocalRepositorySearcher.java
@@ -23,6 +23,8 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Set;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 import java.util.stream.Collectors;
 
 import org.apache.maven.artifact.versioning.ArtifactVersion;
@@ -31,7 +33,9 @@ import org.apache.maven.index.artifact.Gav;
 import org.apache.maven.model.Dependency;
 
 public class LocalRepositorySearcher {
-	
+
+	private static final Logger LOGGER = Logger.getLogger(LocalRepositorySearcher.class.getName());
+
 	private final File localRepository;
 
 	public LocalRepositorySearcher(File localRepository) {
@@ -69,7 +73,7 @@ public class LocalRepositorySearcher {
 						key.reset();
 					}
 				} catch (InterruptedException e) {
-					e.printStackTrace();
+					LOGGER.log(Level.SEVERE, e.getCause().toString(), e);
 				}
 			}).start();
 			cache.put(localRepository, res);
@@ -80,7 +84,7 @@ public class LocalRepositorySearcher {
 	public Collection<Gav> computeLocalArtifacts() throws IOException {
 		final Path repoPath = localRepository.toPath();
 		Map<String, Gav> groupIdArtifactIdToVersion = new HashMap<>();
-		Files.walkFileTree(repoPath, Collections.emptySet(), 10, new SimpleFileVisitor<Path>() { 
+		Files.walkFileTree(repoPath, Collections.emptySet(), 10, new SimpleFileVisitor<Path>() {
 			@Override
 			public FileVisitResult preVisitDirectory(Path file, BasicFileAttributes attrs) throws IOException {
 				if (file.getFileName().toString().charAt(0) == '.') {
@@ -114,7 +118,7 @@ public class LocalRepositorySearcher {
 		return groupIdArtifactIdToVersion.values();
 	}
 
-	
+
 	// TODO consider using directly ArtifactRepository for those 2 methods
 	public File findLocalFile(Dependency dependency) {
 		return new File(localRepository, dependency.getGroupId().replace('.', File.separatorChar) + File.separatorChar + dependency.getArtifactId() + File.separatorChar + dependency.getVersion() + File.separatorChar + dependency.getArtifactId() + '-' + dependency.getVersion() + ".pom");
@@ -129,7 +133,7 @@ public class LocalRepositorySearcher {
 			try {
 				watchService.close();
 			} catch (IOException e) {
-				e.printStackTrace();
+				LOGGER.log(Level.SEVERE, e.getCause().toString(), e);
 			}
 			watchKey = null;
 			watchService = null;

--- a/lemminx-maven/src/main/java/org/eclipse/lemminx/maven/snippets/SnippetRegistry.java
+++ b/lemminx-maven/src/main/java/org/eclipse/lemminx/maven/snippets/SnippetRegistry.java
@@ -16,6 +16,8 @@ import java.util.Collection;
 import java.util.List;
 import java.util.Objects;
 import java.util.function.Predicate;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 import java.util.stream.Collectors;
 
 import org.eclipse.lemminx.commons.BadLocationException;
@@ -35,6 +37,7 @@ import com.google.gson.stream.JsonReader;
 
 public class SnippetRegistry {
 
+	private static final Logger LOGGER = Logger.getLogger(SnippetRegistry.class.getName());
 	private static final SnippetRegistry INSTANCE = new SnippetRegistry();
 
 	public static SnippetRegistry getInstance() {
@@ -68,7 +71,7 @@ public class SnippetRegistry {
 				whitespacesIndent = StringUtils.getStartWhitespaces(lineText);
 			} catch (BadLocationException e) {
 				// TODO Auto-generated catch block
-				e.printStackTrace();
+				LOGGER.log(Level.SEVERE, e.getCause().toString(), e);
 			}
 		}
 
@@ -110,7 +113,7 @@ public class SnippetRegistry {
 	}
 
 	public Collection<CompletionItem> getCompletionItems(TextDocument document, int completionOffset,
-			boolean canSupportMarkdown, Predicate<SnippetContext> contextFilter) {
+														 boolean canSupportMarkdown, Predicate<SnippetContext> contextFilter) {
 		LineContext lineContext = new LineContext(document, completionOffset);
 		return getSnippets().stream().filter(s -> {
 			if (s.getContext() == null) {
@@ -137,7 +140,7 @@ public class SnippetRegistry {
 				item.setInsertTextFormat(InsertTextFormat.Snippet);
 				return item;
 			} catch (BadLocationException e) {
-				e.printStackTrace();
+				LOGGER.log(Level.SEVERE, e.getCause().toString(), e);
 				return null;
 			}
 
@@ -145,7 +148,7 @@ public class SnippetRegistry {
 	}
 
 	private static MarkupContent createDocumentation(Snippet snippet, boolean canSupportMarkdown,
-			LineContext lineContext) {
+													 LineContext lineContext) {
 		String description = snippet.getDescription();
 		StringBuilder doc = new StringBuilder(description);
 		doc.append(System.lineSeparator());
@@ -195,7 +198,7 @@ public class SnippetRegistry {
 		}
 		return new Range(document.positionAt(replaceStart), document.positionAt(replaceEnd));
 	}
-	
+
 	private static int findExprBeforeAt(String text, String expr, int offset) {
 		if (offset <= 0) {
 			return -1;


### PR DESCRIPTION
Replace logging that used e.printStackTrace, System.err, and System.out with java.util.logging.Logger.