### PR TITLE
Test downloading remote artifact from non central repo

### DIFF
--- a/lemminx-maven/src/test/java/org/eclipse/lemminx/maven/test/RemoteRepositoryTest.java
+++ b/lemminx-maven/src/test/java/org/eclipse/lemminx/maven/test/RemoteRepositoryTest.java
@@ -118,6 +118,26 @@ public class RemoteRepositoryTest {
 	}
 	
 	@Test(timeout=15000)
+ 	public void testDownloadNonCentralArtifactOnHover() throws IOException, InterruptedException, ExecutionException, URISyntaxException {
+		languageService.initializeIfNeeded();
+		File mavenRepo = languageService.getExtensions().stream() //
+			.filter(MavenLemminxExtension.class::isInstance) //
+			.map(MavenLemminxExtension.class::cast) //
+			.findAny() //
+			.map(mavenLemminxPlugin -> mavenLemminxPlugin.getMavenSession().getRepositorySession().getLocalRepository().getBasedir())
+			.get();
+		
+		File artifactDirectory = new File(mavenRepo, "com/github/goxr3plus/java-stream-player/9.0.4");
+		final DOMDocument document = createDOMDocument("/pom-remote-artifact-non-central-download-hover.xml", languageService);
+		final Position position = new Position(14, 20);
+		assertFalse(artifactDirectory.exists());
+ 		languageService.doHover(document, position, new SharedSettings());
+ 		
+ 		assertTrue(artifactDirectory.exists());
+ 		assertTrue(artifactDirectory.listFiles().length > 0);
+	}
+	
+	@Test(timeout=15000)
 	public void testRemotePluginGroupIdCompletion() throws IOException, InterruptedException, ExecutionException, URISyntaxException {
 		loopUntilCompletionItemFound(createDOMDocument("/pom-remote-plugin-groupId-complete.xml", languageService), //
 				new Position(11, 14), "org.codehaus.mojo");

--- a/lemminx-maven/src/test/resources/pom-remote-artifact-non-central-download-hover.xml
+++ b/lemminx-maven/src/test/resources/pom-remote-artifact-non-central-download-hover.xml
@@ -1,0 +1,26 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+	<modelVersion>4.0.0</modelVersion>
+
+	<groupId>org.test</groupId>
+	<artifactId>test</artifactId>
+	<version>0.0.1-SNAPSHOT</version>
+	<packaging>pom</packaging>
+
+
+	<dependencies>
+	<dependency>
+		<groupId>com.github.goxr3plus</groupId>
+		<artifactId>java-stream-player</artifactId>
+		<version>9.0.4</version>
+	</dependency>
+	</dependencies>
+<repositories>
+	<repository>
+	   <id>jitpack.io</id>
+	   <url>https://jitpack.io</url>
+        </repository>
+	</repositories>
+
+</project>


### PR DESCRIPTION
Part of #104

Note that m2e's update project feature is not able to download
jascut:jascut:0.0.3 either.

This issue also occurs for org.tmatesoft.svnkit:svnkit:1.3.8

Signed-off-by: Andrew Obuchowicz <andrew@aobuchow.com>