### PR TITLE
Avoid eager download of index

### DIFF
--- a/lemminx-maven/src/main/java/org/eclipse/lemminx/maven/MavenCompletionParticipant.java
+++ b/lemminx-maven/src/main/java/org/eclipse/lemminx/maven/MavenCompletionParticipant.java
@@ -523,20 +523,6 @@ public class MavenCompletionParticipant extends CompletionParticipantAdapter {
 	}
 
 	private Collection<CompletionItem> completeProperties(ICompletionRequest request) {
-		DOMDocument xmlDocument = request.getXMLDocument();
-		String documentText = xmlDocument.getText();
-		int initialPropertyOffset = request.getOffset();
-		for (int i = request.getOffset() - 1; i >= request.getNode().getStart(); i--) {
-			char currentChar = documentText.charAt(i);
-			if (currentChar == '}') {
-				// properties area ended, return all properties
-				break;
-			} else if (currentChar == '$') {
-				initialPropertyOffset = i;
-				break;
-			}
-		}
-
 		MavenProject project = plugin.getProjectCache().getLastSuccessfulMavenProject(request.getXMLDocument());
 		if (project == null) {
 			return Collections.emptySet();
@@ -575,12 +561,11 @@ public class MavenCompletionParticipant extends CompletionParticipantAdapter {
 
 		Range range = XMLPositionUtility.createRange(node.getStartTagCloseOffset() + 1, node.getEndTagOpenOffset(),
 				doc);
-		List<String> remoteArtifactRepositories = Collections.singletonList(RemoteRepositoryIndexSearcher.CENTRAL_REPO.getUrl());
-		Dependency artifactToSearch = MavenParseUtils.parseArtifact(node);
 		MavenProject project = plugin.getProjectCache().getLastSuccessfulMavenProject(doc);
-		if (project != null) {
-			remoteArtifactRepositories = project.getRemoteArtifactRepositories().stream().map(ArtifactRepository::getUrl).collect(Collectors.toList());
-		}
+		List<String> remoteArtifactRepositories = project != null ? //
+				project.getRemoteArtifactRepositories().stream().map(ArtifactRepository::getUrl).collect(Collectors.toList()) : //
+				Collections.singletonList(RemoteRepositoryIndexSearcher.CENTRAL_REPO.getUrl());
+		Dependency artifactToSearch = MavenParseUtils.parseArtifact(node);
 		Set<CompletionItem> updateItems = Collections.synchronizedSet(new HashSet<>(remoteArtifactRepositories.size()));
 		RemoteRepositoryIndexSearcher indexSearcher = plugin.getIndexSearcher();
 		try {

--- a/lemminx-maven/src/main/java/org/eclipse/lemminx/maven/MavenLemminxExtension.java
+++ b/lemminx-maven/src/main/java/org/eclipse/lemminx/maven/MavenLemminxExtension.java
@@ -138,7 +138,6 @@ public class MavenLemminxExtension implements IXMLExtension {
 			cache = new MavenProjectCache(this);
 			localRepositorySearcher = new LocalRepositorySearcher(mavenSession.getRepositorySession().getLocalRepository().getBasedir());
 			indexSearcher = new RemoteRepositoryIndexSearcher(this, container, Optional.ofNullable(options.get("maven.indexLocation")).map(JsonElement::getAsString).map(File::new));
-			cache.addProjectParsedListener(indexSearcher::updateKnownRepositories);
 			buildPluginManager = null;
 			mavenPluginManager = container.lookup(MavenPluginManager.class);
 			buildPluginManager = container.lookup(BuildPluginManager.class);

--- a/lemminx-maven/src/main/java/org/eclipse/lemminx/maven/MavenProjectCache.java
+++ b/lemminx-maven/src/main/java/org/eclipse/lemminx/maven/MavenProjectCache.java
@@ -228,8 +228,4 @@ public class MavenProjectCache {
 		return plexusContainer;
 	}
 
-	public void addProjectParsedListener(Consumer<MavenProject> listener) {
-		this.projectParsedListeners.add(listener);
-	}
-
 }

--- a/lemminx-maven/src/test/java/org/eclipse/lemminx/maven/test/RemoteRepositoryTest.java
+++ b/lemminx-maven/src/test/java/org/eclipse/lemminx/maven/test/RemoteRepositoryTest.java
@@ -151,7 +151,7 @@ public class RemoteRepositoryTest {
 		// if got out of the loop without timeout, then test is PASSED
 	}
 	
-	@Test(timeout=15000)
+	@Test
 	public void testRemotePluginVersionCompletion() throws IOException, InterruptedException, ExecutionException, URISyntaxException {
 		loopUntilCompletionItemFound(createDOMDocument("/pom-remote-plugin-version-complete.xml", languageService), //
 				new Position(13, 12), "1.0-beta-1");


### PR DESCRIPTION
Index are only downloaded on demand for hover or completion.
As a result, the results of such hover or completion may be delayed
(when index is necessary eg when local repo doesn't contain useful
data), but that avoid a lot of download and CPU consumption when just
reading poms or just hooking the language server without really using
it.

Signed-off-by: Mickael Istria <mistria@redhat.com>