### PR TITLE
test(plugin): add plugin goal validation test

### DIFF
--- a/lemminx-maven/src/test/java/org/eclipse/lemminx/extensions/maven/test/PluginResolutionTest.java
+++ b/lemminx-maven/src/test/java/org/eclipse/lemminx/extensions/maven/test/PluginResolutionTest.java
@@ -16,12 +16,16 @@ import java.io.File;
 import java.io.IOException;
 import java.net.URISyntaxException;
 import java.util.Arrays;
+import java.util.List;
 import java.util.concurrent.ExecutionException;
 
 import org.apache.commons.io.FileUtils;
+import org.eclipse.lemminx.extensions.contentmodel.settings.XMLValidationSettings;
+import org.eclipse.lemminx.extensions.maven.MavenDiagnosticParticipant;
 import org.eclipse.lemminx.extensions.maven.MavenLemminxExtension;
 import org.eclipse.lemminx.services.XMLLanguageService;
 import org.eclipse.lemminx.settings.SharedSettings;
+import org.eclipse.lsp4j.Diagnostic;
 import org.eclipse.lsp4j.HoverCapabilities;
 import org.eclipse.lsp4j.MarkupKind;
 import org.eclipse.lsp4j.Position;
@@ -90,5 +94,18 @@ public class PluginResolutionTest {
 		assertTrue(hoverContents.contains("**Type:** List&lt;String&gt;"));
 		assertTrue(hoverContents.contains("Sets the arguments to be passed to the compiler"));
 	}
+	
+	@Test
+    public void testPluginGoalValidationWithPluginWithJDKProfiles()
+            throws IOException, InterruptedException, ExecutionException, URISyntaxException {
+        MavenLemminxExtension plugin = new MavenLemminxExtension();
+        MavenDiagnosticParticipant mavenDiagnosticParticipant = new MavenDiagnosticParticipant(plugin);
+        languageService.getDiagnosticsParticipants().add(mavenDiagnosticParticipant);
+        List<Diagnostic> diagnostics = languageService.doDiagnostics(createDOMDocument("/pom-plugin-goal-resolution.xml", languageService),
+                new XMLValidationSettings(), 
+                () -> {});
+        
+        assertTrue("No validation error or warning found", diagnostics.isEmpty());
+    }
 
 }

--- a/lemminx-maven/src/test/resources/pom-plugin-goal-resolution.xml
+++ b/lemminx-maven/src/test/resources/pom-plugin-goal-resolution.xml
@@ -1,0 +1,28 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+	<groupId>org.company</groupId>
+	<artifactId>jacoco-plugin-resolution</artifactId>
+	<version>0.0.1-SNAPSHOT</version>
+
+	<build>
+		<pluginManagement>
+			<plugins>
+				<plugin>
+					<groupId>org.jacoco</groupId>
+					<artifactId>jacoco-maven-plugin</artifactId>
+					<version>0.8.5</version>
+					<executions>
+						<execution>
+							<id>prepare-agent</id>
+							<goals>
+								<goal>prepare-agent</goal>
+							</goals>
+						</execution>
+					</executions>
+				</plugin>
+			</plugins>
+		</pluginManagement>
+	</build>
+</project>


### PR DESCRIPTION
Add plugin validation test checking that no error or wrning is thrown when the plugin contains jdk specific profile activation rule like:

```
  <profiles>
    <profile>
      <id>maven-jdk9</id>
      <activation>
        <jdk>[9,12)</jdk>
      </activation>
       ...
    </profile>

    <profile>
      <id>maven-jdk12</id>
      <activation>
        <jdk>[12,)</jdk>
      </activation>
       ...
    </profile>
```

The test is failing in 0.1.1 and has been fixed with
https://github.com/eclipse/lemminx-maven/commit/d626869e57787166008d2a098524e408a0fc3dbd