### PR TITLE
Fix artifact completion in <dependencies> in VSCode

### DIFF
--- a/lemminx-maven/src/main/java/org/eclipse/lemminx/extensions/maven/MavenLemminxExtension.java
+++ b/lemminx-maven/src/main/java/org/eclipse/lemminx/extensions/maven/MavenLemminxExtension.java
@@ -5,7 +5,7 @@
  * which is available at https://www.eclipse.org/legal/epl-2.0/
  *
  * SPDX-License-Identifier: EPL-2.0
- * 
+ *
  * Contributors:
  * Angelo Zerr <angelo.zerr@gmail.com> - initial API and implementation
  *******************************************************************************/
@@ -69,7 +69,7 @@ public class MavenLemminxExtension implements IXMLExtension {
 	private static final String MAVEN_XMLLS_EXTENSION_REALM_ID = MavenLemminxExtension.class.getName();
 
 	private XMLExtensionsRegistry currentRegistry;
-	
+
 	private ICompletionParticipant completionParticipant;
 	private IDiagnosticsParticipant diagnosticParticipant;
 	private IHoverParticipant hoverParticipant;
@@ -92,14 +92,18 @@ public class MavenLemminxExtension implements IXMLExtension {
 		if (context.getType() == SaveContextType.SETTINGS) {
 			final XMLExtensionsRegistry registry = this.currentRegistry; // keep ref as this.currentRegistry becomes null on stop
 			stop(registry);
-			params.setInitializationOptions(context.getSettings());
+			if (params != null) {
+				params.setInitializationOptions(context.getSettings());
+			}
 			start(params, registry);
 		}
 	}
 
 	@Override
 	public void start(InitializeParams params, XMLExtensionsRegistry registry) {
-		this.params = params;
+		if (params != null) {
+			this.params = params;
+		}
 		this.currentRegistry = registry;
 		try {
 			// Do not invoke getters the MavenLemminxExtension in participant constructors,
@@ -303,12 +307,12 @@ public class MavenLemminxExtension implements IXMLExtension {
 		initialize();
 		return localRepositorySearcher;
 	}
-	
+
 	public MavenPluginManager getMavenPluginManager() {
 		initialize();
 		return mavenPluginManager;
 	}
-	
+
 	public Optional<RemoteRepositoryIndexSearcher> getIndexSearcher() {
 		initialize();
 		return Optional.ofNullable(indexSearcher);

--- a/lemminx-maven/src/test/java/org/eclipse/lemminx/extensions/maven/test/LemminxMavenCompletionParticipantTest.java
+++ b/lemminx-maven/src/test/java/org/eclipse/lemminx/extensions/maven/test/LemminxMavenCompletionParticipantTest.java
@@ -1,0 +1,110 @@
+/*******************************************************************************
+ * Copyright (c) 2021 Red Hat Inc. and others.
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+package org.eclipse.lemminx.extensions.maven.test;
+
+import static org.eclipse.lemminx.XMLAssert.c;
+import static org.eclipse.lemminx.XMLAssert.te;
+
+import org.eclipse.lemminx.XMLAssert;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+@ExtendWith(NoMavenCentralIndexExtension.class)
+public class LemminxMavenCompletionParticipantTest {
+
+	@Test
+	public void testOneExistingDependencyDependenciesCompletion() throws Exception {
+		String pom = //
+				"<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n" + //
+				"<project\n" + //
+				"  xsi:schemaLocation=\"http://maven.apache.org/POM/4.0.0\n" + //
+				"                      https://maven.apache.org/xsd/maven-4.0.0.xsd\"\n" + //
+				"  xmlns=\"http://maven.apache.org/POM/4.0.0\"\n" + //
+				"  xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\">\n" + //
+				"  <modelVersion>4.0.0</modelVersion>\n" + //
+				"  <artifactId>just-a-pom</artifactId>\n" + //
+				"  <groupId>com.datho7561</groupId>\n" + //
+				"  <version>0.1.0</version>\n" + //
+				"  <dependencies>\n" + //
+				"    <dependency>\n" + //
+				"      <groupId>com.fasterxml.jackson.core</groupId>\n" + //
+				"      <artifactId>jackson-core</artifactId>\n" + //
+				"      <version>2.11.3</version>\n" + //
+				"    </dependency>\n" + //
+				"    maven-core|\n" + //
+				"  </dependencies>\n" + //
+				"</project>\n";
+		XMLAssert.testCompletionFor(pom, null, "file:///pom.xml", null, //
+				c("maven-core - org.apache.maven:maven-core:3.0", //
+				te(16, 4, 16, 14, //
+						"<dependency>\n" + //
+						"      <groupId>org.apache.maven</groupId>\n" + //
+						"      <artifactId>maven-core</artifactId>\n" + //
+						"      <version>3.0</version>\n" + //
+						"    </dependency>"),
+				"maven-core"));
+	}
+
+	@Test
+	public void testNoExistingDependencyDependenciesCompletion() throws Exception {
+		String pom = //
+				"<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n" + //
+				"<project\n" + //
+				"  xsi:schemaLocation=\"http://maven.apache.org/POM/4.0.0\n" + //
+				"                      https://maven.apache.org/xsd/maven-4.0.0.xsd\"\n" + //
+				"  xmlns=\"http://maven.apache.org/POM/4.0.0\"\n" + //
+				"  xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\">\n" + //
+				"  <modelVersion>4.0.0</modelVersion>\n" + //
+				"  <artifactId>just-a-pom</artifactId>\n" + //
+				"  <groupId>com.datho7561</groupId>\n" + //
+				"  <version>0.1.0</version>\n" + //
+				"  <dependencies>\n" + //
+				"    maven-core|\n" + //
+				"  </dependencies>\n" + //
+				"</project>\n";
+		XMLAssert.testCompletionFor(pom, null, "file:///pom.xml", null, //
+				c("maven-core - org.apache.maven:maven-core:3.0", //
+				te(11, 4, 11, 14, //
+						"<dependency>\n" + //
+						"      <groupId>org.apache.maven</groupId>\n" + //
+						"      <artifactId>maven-core</artifactId>\n" + //
+						"      <version>3.0</version>\n" + //
+						"    </dependency>"),
+				"maven-core"));
+	}
+
+	@Test
+	public void testNoExistingDependencyDependencyCompletion() throws Exception {
+		String pom = //
+				"<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n" + //
+				"<project\n" + //
+				"  xsi:schemaLocation=\"http://maven.apache.org/POM/4.0.0\n" + //
+				"                      https://maven.apache.org/xsd/maven-4.0.0.xsd\"\n" + //
+				"  xmlns=\"http://maven.apache.org/POM/4.0.0\"\n" + //
+				"  xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\">\n" + //
+				"  <modelVersion>4.0.0</modelVersion>\n" + //
+				"  <artifactId>just-a-pom</artifactId>\n" + //
+				"  <groupId>com.datho7561</groupId>\n" + //
+				"  <version>0.1.0</version>\n" + //
+				"  <dependencies>\n" + //
+				"    <dependency>\n" + //
+				"      maven-core|\n" + //
+				"    </dependency>\n" + //
+				"  </dependencies>\n" + //
+				"</project>\n";
+		XMLAssert.testCompletionFor(pom, null, "file:///pom.xml", null, //
+				c("maven-core - org.apache.maven:maven-core:3.0", //
+				te(12, 6, 12, 16, //
+						"<groupId>org.apache.maven</groupId>\n" + //
+						"      <artifactId>maven-core</artifactId>\n" + //
+						"      <version>3.0</version>"),
+				"maven-core"));
+	}
+
+}


### PR DESCRIPTION
Adjust the replace range of the TextEdit of the completion item so that it covers just the text node. This prevents VSCode from filtering the completion result.

Closes #180

Signed-off-by: David Thompson <davthomp@redhat.com>
