### PR TITLE
Add support for Maven XML settings in the JSON model.

### DIFF
--- a/lemminx-maven/src/main/java/org/eclipse/lemminx/extensions/maven/XMLMavenGeneralSettings.java
+++ b/lemminx-maven/src/main/java/org/eclipse/lemminx/extensions/maven/XMLMavenGeneralSettings.java
@@ -1,0 +1,37 @@
+/*******************************************************************************
+ * Copyright (c) 2021 Red Hat Inc. and others.
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ * Red Hat Inc. - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.lemminx.extensions.maven;
+
+import org.eclipse.lemminx.settings.XMLGeneralClientSettings;
+import org.eclipse.lemminx.utils.JSONUtility;
+
+public class XMLMavenGeneralSettings extends XMLGeneralClientSettings {
+
+	public XMLMavenGeneralSettings() {
+		setMaven(new XMLMavenSettings());
+	}
+
+	private XMLMavenSettings maven;
+
+	public XMLMavenSettings getMaven() {
+		return maven;
+	}
+
+	public void setMaven(XMLMavenSettings maven) {
+		this.maven = maven;
+	}
+
+	public static XMLMavenGeneralSettings getGeneralXMLSettings(Object initializationOptionsSettings) {
+		return JSONUtility.toModel(initializationOptionsSettings, XMLMavenGeneralSettings.class);
+	}
+
+}

--- a/lemminx-maven/src/main/java/org/eclipse/lemminx/extensions/maven/XMLMavenIndexSettings.java
+++ b/lemminx-maven/src/main/java/org/eclipse/lemminx/extensions/maven/XMLMavenIndexSettings.java
@@ -1,0 +1,25 @@
+/*******************************************************************************
+ * Copyright (c) 2021 Red Hat Inc. and others.
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ * Red Hat Inc. - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.lemminx.extensions.maven;
+
+public class XMLMavenIndexSettings {
+
+	private boolean skip;
+
+	public boolean isSkip() {
+		return skip;
+	}
+
+	public void setSkip(boolean skip) {
+		this.skip = skip;
+	}
+}

--- a/lemminx-maven/src/main/java/org/eclipse/lemminx/extensions/maven/XMLMavenRepoSettings.java
+++ b/lemminx-maven/src/main/java/org/eclipse/lemminx/extensions/maven/XMLMavenRepoSettings.java
@@ -1,0 +1,26 @@
+/*******************************************************************************
+ * Copyright (c) 2021 Red Hat Inc. and others.
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ * Red Hat Inc. - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.lemminx.extensions.maven;
+
+public class XMLMavenRepoSettings {
+
+	private String local;
+
+	public String getLocal() {
+		return local;
+	}
+
+	public void setLocal(String local) {
+		this.local = local;
+	}
+
+}

--- a/lemminx-maven/src/main/java/org/eclipse/lemminx/extensions/maven/XMLMavenSettings.java
+++ b/lemminx-maven/src/main/java/org/eclipse/lemminx/extensions/maven/XMLMavenSettings.java
@@ -1,0 +1,71 @@
+/*******************************************************************************
+ * Copyright (c) 2021 Red Hat Inc. and others.
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ * Red Hat Inc. - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.lemminx.extensions.maven;
+
+public class XMLMavenSettings {
+
+	private XMLMavenIndexSettings index;
+
+	private XMLMavenRepoSettings repo;
+
+	private String globalSettings;
+
+	private String userSettings;
+
+	private String indexLocation;
+
+	public XMLMavenSettings() {
+		setIndex(new XMLMavenIndexSettings());
+		setRepo(new XMLMavenRepoSettings());
+	}
+
+	public XMLMavenIndexSettings getIndex() {
+		return index;
+	}
+
+	public void setIndex(XMLMavenIndexSettings index) {
+		this.index = index;
+	}
+
+	public XMLMavenRepoSettings getRepo() {
+		return repo;
+	}
+
+	public void setRepo(XMLMavenRepoSettings repo) {
+		this.repo = repo;
+	}
+
+	public String getUserSettings() {
+		return userSettings;
+	}
+
+	public void setUserSettings(String userSettings) {
+		this.userSettings = userSettings;
+	}
+
+	public String getGlobalSettings() {
+		return globalSettings;
+	}
+
+	public void setGlobalSettings(String globalSettings) {
+		this.globalSettings = globalSettings;
+	}
+
+	public String getIndexLocation() {
+		return indexLocation;
+	}
+
+	public void setIndexLocation(String indexLocation) {
+		this.indexLocation = indexLocation;
+	}
+
+}


### PR DESCRIPTION
- Resolves #193
- Add support for properties prefixed with "xml.maven.*"

Signed-off-by: Roland Grunberg <rgrunber@redhat.com>