### PR TITLE
Fix #196: lemminx-maven completely ignore local settings

### DIFF
--- a/lemminx-maven/src/main/java/org/eclipse/lemminx/extensions/maven/MavenLemminxExtension.java
+++ b/lemminx-maven/src/main/java/org/eclipse/lemminx/extensions/maven/MavenLemminxExtension.java
@@ -181,7 +181,7 @@ public class MavenLemminxExtension implements IXMLExtension {
 				requestPopulator.populateFromSettings(mavenRequest, userSettings);
 			}
 		}
-		mavenRequest.setLocalRepositoryPath(RepositorySystem.defaultUserLocalRepository);
+
 		String localRepoProperty = System.getProperty("maven.repo.local");
 		if (localRepoProperty != null) {
 			mavenRequest.setLocalRepositoryPath(new File(localRepoProperty));
@@ -192,6 +192,10 @@ public class MavenLemminxExtension implements IXMLExtension {
 			if (candidate.isFile() && candidate.canRead()) {
 				mavenRequest.setLocalRepositoryPath(candidate);
 			}
+		}
+
+		if (mavenRequest.getLocalRepositoryPath() == null) {
+			mavenRequest.setLocalRepositoryPath(RepositorySystem.defaultUserLocalRepository);
 		}
 
 		RepositorySystem repositorySystem = container.lookup(RepositorySystem.class);
@@ -206,11 +210,13 @@ public class MavenLemminxExtension implements IXMLExtension {
 		return mavenRequest;
 	}
 
+
+
 	private static File getFileFromOptions(String element, File defaults) {
 		if (element == null) {
 			return defaults;
 		}
-		if (element != null && !element.trim().isEmpty()) {
+		if (!element.trim().isEmpty()) {
 			File globalSettingsCandidate = new File(element);
 			if (globalSettingsCandidate.canRead()) {
 				return globalSettingsCandidate;


### PR DESCRIPTION
  Do not change the LocalRepositoryPath to the default RepositorySystem.defaultUserLocalRepository if there some existing
  path.