### PR TITLE
Fix the indexer exception issues

### DIFF
--- a/lemminx-maven/src/main/java/org/eclipse/lemminx/extensions/maven/searcher/LocalRepositorySearcher.java
+++ b/lemminx-maven/src/main/java/org/eclipse/lemminx/extensions/maven/searcher/LocalRepositorySearcher.java
@@ -10,6 +10,7 @@ package org.eclipse.lemminx.extensions.maven.searcher;
 
 import java.io.File;
 import java.io.IOException;
+import java.nio.file.ClosedWatchServiceException;
 import java.nio.file.FileVisitResult;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -69,9 +70,13 @@ public class LocalRepositorySearcher {
 				WatchKey key;
 				try {
 					while ((key = watchService.take()) != null) {
-						cache.remove(localRepository);
-						key.reset();
+						if (watchKey.equals(key)) {
+							cache.remove(localRepository);
+							key.reset();
+						}
 					}
+				} catch (ClosedWatchServiceException e) {
+					LOGGER.log(Level.WARNING, "Local repo thread watcher is closed");
 				} catch (InterruptedException e) {
 					LOGGER.log(Level.SEVERE, "Local repo thread watcher interrupted", e);
 				}


### PR DESCRIPTION
The change fixes a number of NPPE and other kind of excceptions that appear in build log output
when the Cantral Maven Repository is disabled, like:

```
Caused by: java.lang.IllegalArgumentException: context mustn't be null
	at org.eclipse.lemminx.extensions.maven.searcher.RemoteRepositoryIndexSearcher.lambda$updateIndex$3(RemoteRepositoryIndexSearcher.java:229)
```
and
```
Caused by: java.lang.IllegalArgumentException: context mustn't be null
	at org.eclipse.lemminx.extensions.maven.searcher.RemoteRepositoryIndexSearcher.lambda$updateIndex$3(RemoteRepositoryIndexSearcher.java:229)
```
as well as some other exceptions.

Signed-off-by: Victor Rubezhny <vrubezhny@redhat.com>