### PR TITLE
Fix #214 : plugin resolution support from custom remote repositories

### DIFF
--- a/lemminx-maven/src/main/java/org/eclipse/lemminx/extensions/maven/utils/MavenPluginUtils.java
+++ b/lemminx-maven/src/main/java/org/eclipse/lemminx/extensions/maven/utils/MavenPluginUtils.java
@@ -174,10 +174,9 @@ public class MavenPluginUtils {
 			throw new InvalidPluginDescriptorException("Unable to resolve " + pluginKey, Collections.emptyList());
 		}
 
-		return lemminxMavenPlugin.getMavenPluginManager()
-				.getPluginDescriptor(plugin, project.getPluginRepositories().stream()
-						.map(MavenPluginUtils::toRemoteRepo).collect(Collectors.toList()),
-						lemminxMavenPlugin.getMavenSession().getRepositorySession());
+		return lemminxMavenPlugin.getMavenPluginManager().getPluginDescriptor(plugin,
+				project.getRemotePluginRepositories().stream().collect(Collectors.toList()),
+				lemminxMavenPlugin.getMavenSession().getRepositorySession());
 	}
 
 }


### PR DESCRIPTION
When resolving plugin configurations it was always used the central
repository instead of what is configured in settings. With this fix the
plugins repositories from settings are used.

Signed-off-by: Gayan Perera <gayanper@gmail.com>