### PR TITLE
Maven Projects are built and cached more than once  when relative pat…

### DIFF
--- a/lemminx-maven/src/main/java/org/eclipse/lemminx/extensions/maven/MavenProjectCache.java
+++ b/lemminx-maven/src/main/java/org/eclipse/lemminx/extensions/maven/MavenProjectCache.java
@@ -86,7 +86,7 @@ public class MavenProjectCache {
 	 */
 	public MavenProject getLastSuccessfulMavenProject(DOMDocument document) {
 		check(document);
-		return projectCache.get(URI.create(document.getTextDocument().getUri()));
+		return projectCache.get(URI.create(document.getTextDocument().getUri()).normalize());
 	}
 
 	/**
@@ -97,18 +97,18 @@ public class MavenProjectCache {
 	 */
 	public Collection<ModelProblem> getProblemsFor(DOMDocument document) {
 		check(document);
-		return problemCache.get(URI.create(document.getTextDocument().getUri()));
+		return problemCache.get(URI.create(document.getTextDocument().getUri()).normalize());
 	}
 
 	private void check(DOMDocument document) {
-		Integer last = lastCheckedVersion.get(URI.create(document.getTextDocument().getUri()));
+		Integer last = lastCheckedVersion.get(URI.create(document.getTextDocument().getUri()).normalize());
 		if (last == null || last.intValue() < document.getTextDocument().getVersion()) {
 			parseAndCache(document);
 		}
 	}
 
 	public Optional<MavenProject> getSnapshotProject(File file) {
-		MavenProject lastKnownVersionMavenProject = projectCache.get(file.toURI());
+		MavenProject lastKnownVersionMavenProject = projectCache.get(file.toURI().normalize());
 		if (lastKnownVersionMavenProject != null) {
 			return Optional.of(lastKnownVersionMavenProject);
 		}
@@ -126,7 +126,7 @@ public class MavenProjectCache {
 	}
 
 	private void parseAndCache(DOMDocument document) {
-		URI uri = URI.create(document.getDocumentURI());
+		URI uri = URI.create(document.getDocumentURI()).normalize();
 		Collection<ModelProblem> problems = new ArrayList<>();
 		try {
 			ProjectBuildingResult buildResult = projectBuilder.build(new FileModelSource(new File(uri)) {


### PR DESCRIPTION
…hs are used

It's possible that the same maven project is built and cached two or more times when its URI  calculated relatively to its child proect.
For example, for the following URIs:

	file:/home/user/projects/maven-hierarchy-test/child/grandchild/../../pom.xml
	file:/home/user/projects/maven-hierarchy-test/pom.xml

we'll have two copies of the same maven project built and saved into the Maven Project Cache

Signed-off-by: Victor Rubezhny <vrubezhny@redhat.com>