### PR TITLE
Update to JUnit 5.9.1

### DIFF
--- a/lemminx-maven/pom.xml
+++ b/lemminx-maven/pom.xml
@@ -23,7 +23,7 @@
 		<project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
 		<lemminx.maven.indexDirectory>${project.build.directory}/test-index</lemminx.maven.indexDirectory>
 		<maven.repo.local>${settings.localRepository}</maven.repo.local>
-		<junit-jupiter.version>5.8.2</junit-jupiter.version>
+		<junit-jupiter.version>5.9.1</junit-jupiter.version>
 		<lemminx.version>0.21.0</lemminx.version>
 		<maven.version>3.8.5</maven.version>
 	</properties>

--- a/lemminx-maven/src/test/java/org/eclipse/lemminx/extensions/maven/participants/RemoteCentralRepoTest.java
+++ b/lemminx-maven/src/test/java/org/eclipse/lemminx/extensions/maven/participants/RemoteCentralRepoTest.java
@@ -22,16 +22,16 @@ import org.eclipse.lemminx.extensions.maven.searcher.RemoteCentralRepositorySear
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
-public class RemoteCentralRepoTest {
+class RemoteCentralRepoTest {
 	private static RemoteCentralRepositorySearcher repoSearcher = new RemoteCentralRepositorySearcher(null);
 	
 	@BeforeAll
-	private static void setup() {
+	static void setup() {
 		RemoteCentralRepositorySearcher.disableCentralSearch = false;
 	}	
 	
 	@Test
-	public void testGetArtifacts() {
+	void testGetArtifacts() {
 		String G = null;
 		String A = null;
 		String V = null;
@@ -66,7 +66,7 @@ public class RemoteCentralRepoTest {
 	}
 	
 	@Test
-	public void testGetArtifactVersionss() {
+	void testGetArtifactVersionss() {
 
 		String G = "org.fujion.webjars";
 		String A = "webjar-angular";
@@ -87,7 +87,7 @@ public class RemoteCentralRepoTest {
 	}	
 	
 	@Test
-	public void testGetGroupIdss() {
+	void testGetGroupIdss() {
 
 		String G = "org.fujion";
 		
@@ -115,7 +115,7 @@ public class RemoteCentralRepoTest {
 	}	
 		
 	@Test
-	public void testGetPlugiArtifacts() {
+	void testGetPlugiArtifacts() {
 
 		String G = null;
 		String A = null;
@@ -151,7 +151,7 @@ public class RemoteCentralRepoTest {
 	}
 	
 	@Test
-	public void testGetPluginArtifactVersionss() {
+	void testGetPluginArtifactVersionss() {
 
 		String G = "com.github.gianttreelp.proguardservicesmapper";
 		String A = "proguard-services-mapper-maven";
@@ -172,7 +172,7 @@ public class RemoteCentralRepoTest {
 	}	
 	
 	@Test
-	public void testGetPluginGroupIdss() {
+	void testGetPluginGroupIdss() {
 
 		String G = "com.github.gianttreelp.proguardservicesmapper";
 		

--- a/lemminx-maven/src/test/java/org/eclipse/lemminx/extensions/maven/participants/completion/RemoteCentralRepoAssistanceTest.java
+++ b/lemminx-maven/src/test/java/org/eclipse/lemminx/extensions/maven/participants/completion/RemoteCentralRepoAssistanceTest.java
@@ -22,8 +22,6 @@ import org.eclipse.lemminx.extensions.maven.utils.MavenLemminxTestsUtils;
 import org.eclipse.lemminx.services.XMLLanguageService;
 import org.eclipse.lemminx.settings.SharedSettings;
 import org.eclipse.lsp4j.CompletionItem;
-import org.eclipse.lsp4j.Hover;
-import org.eclipse.lsp4j.MarkupContent;
 import org.eclipse.lsp4j.Position;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeAll;
@@ -31,12 +29,12 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
 
-public class RemoteCentralRepoAssistanceTest {
+class RemoteCentralRepoAssistanceTest {
 
 	private XMLLanguageService languageService;
 
 	@BeforeAll
-	private static void setup() {
+	static void setup() {
 		RemoteCentralRepositorySearcher.disableCentralSearch = false;
 	}	
 	
@@ -77,7 +75,7 @@ public class RemoteCentralRepoAssistanceTest {
 
 	@Test
 	@Timeout(value = 15000, unit = TimeUnit.MILLISECONDS)
-	public void testRemoteCentralGroupIdCompletion()
+	void testRemoteCentralGroupIdCompletion()
 			throws IOException, InterruptedException, ExecutionException, URISyntaxException {
 		loopUntilCompletionItemFound(createDOMDocument("/pom-remote-central-groupId-complete.xml"), //
 				new Position(11, 33), "org.fujion.webjars");
@@ -86,7 +84,7 @@ public class RemoteCentralRepoAssistanceTest {
 
 	@Test
 	@Timeout(value = 15000, unit = TimeUnit.MILLISECONDS)
-	public void testRemoteCentralArtifactIdCompletion()
+	void testRemoteCentralArtifactIdCompletion()
 			throws IOException, InterruptedException, ExecutionException, URISyntaxException {
 		loopUntilCompletionItemFound(createDOMDocument("/pom-remote-central-artifactId-complete.xml"), //
 				new Position(12, 24), "webjar-angular - org.fujion.webjars:webjar-angular:");
@@ -95,7 +93,7 @@ public class RemoteCentralRepoAssistanceTest {
 
 	@Test
 	@Timeout(value = 15000, unit = TimeUnit.MILLISECONDS)
-	public void testRemoteCentralVersionCompletion()
+	void testRemoteCentralVersionCompletion()
 			throws IOException, InterruptedException, ExecutionException, URISyntaxException {
 		loopUntilCompletionItemFound(createDOMDocument("/pom-remote-central-version-complete.xml"), //
 				new Position(13, 21), "13.1.1-1");
@@ -104,7 +102,7 @@ public class RemoteCentralRepoAssistanceTest {
 
 	@Test
 	@Timeout(value = 15000, unit = TimeUnit.MILLISECONDS)
-	public void testRemoteCentralPluginGroupIdCompletion()
+	void testRemoteCentralPluginGroupIdCompletion()
 			throws IOException, InterruptedException, ExecutionException, URISyntaxException {
 		loopUntilCompletionItemFound(createDOMDocument("/pom-remote-central-plugin-groupId-complete.xml"), //
 				new Position(12, 45), "com.github.gianttreelp.proguardservicesmapper");
@@ -113,7 +111,7 @@ public class RemoteCentralRepoAssistanceTest {
 
 	@Test
 	@Timeout(value = 15000, unit = TimeUnit.MILLISECONDS)
-	public void testRemoteCentralPluginArtifactIdCompletion()
+	void testRemoteCentralPluginArtifactIdCompletion()
 			throws IOException, InterruptedException, ExecutionException, URISyntaxException {
 		loopUntilCompletionItemFound(createDOMDocument("/pom-remote-central-plugin-artifactId-complete.xml"), //
 				new Position(13, 24), "proguard-services-mapper-maven - com.github.gianttreelp.proguardservicesmapper:proguard-services-mapper-maven:");
@@ -122,7 +120,7 @@ public class RemoteCentralRepoAssistanceTest {
 
 	@Test
 	@Timeout(value = 15000, unit = TimeUnit.MILLISECONDS)
-	public void testRemoteCentralPluginVersionCompletion()
+	void testRemoteCentralPluginVersionCompletion()
 			throws IOException, InterruptedException, ExecutionException, URISyntaxException {
 		loopUntilCompletionItemFound(createDOMDocument("/pom-remote-central-plugin-version-complete.xml"), //
 				new Position(14, 21), "1.0");


### PR DESCRIPTION
BeforeAll can't be private is detected now so fixed. Also changed edited files to no longer have all tests public as it's not required.