### PR TITLE
Fix a possiible deadlock in MavenLemminxWorkspaceReader.findVersion()

### DIFF
--- a/lemminx-maven/src/main/java/org/eclipse/lemminx/extensions/maven/MavenProjectCache.java
+++ b/lemminx-maven/src/main/java/org/eclipse/lemminx/extensions/maven/MavenProjectCache.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2020-2021 Red Hat Inc. and others.
+ * Copyright (c) 2020-2022 Red Hat Inc. and others.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/
@@ -121,6 +121,10 @@ public class MavenProjectCache {
 				MavenProject project = result.get(0).getProject();
 				return Optional.of(project);
 			}
+		} catch (Exception e) {
+			// Some other kinds of exceptions may be thrown, for instance,
+			// an IllegalStateException in case of fail to acquire write lock for an artifact
+			LOGGER.log(Level.SEVERE, e.getMessage(), e);
 		}
 		return Optional.empty();
 	}


### PR DESCRIPTION
"main" #1 prio=5 os_prio=0 cpu=2987.20ms elapsed=191.80s allocated=164M defined_classes=4096 tid=0x00007ff6f0024100 nid=0x1a3cfd waiting on condition  [0x00007ff6f6903000]
   java.lang.Thread.State: TIMED_WAITING (sleeping)
	at java.lang.Thread.sleep(java.base@17.0.2/Native Method)
	at org.eclipse.lemminx.extensions.maven.MavenLemminxWorkspaceReader.findVersions(MavenLemminxWorkspaceReader.java:201)
	at org.apache.maven.repository.internal.DefaultVersionResolver.resolveVersion(DefaultVersionResolver.java:176)
	at org.eclipse.aether.internal.impl.DefaultArtifactResolver.resolve(DefaultArtifactResolver.java:288)
	at org.eclipse.aether.internal.impl.DefaultArtifactResolver.resolveArtifacts(DefaultArtifactResolver.java:235)
	at org.eclipse.aether.internal.impl.DefaultArtifactResolver.resolveArtifact(DefaultArtifactResolver.java:212)
	at org.eclipse.aether.internal.impl.DefaultRepositorySystem.resolveArtifact(DefaultRepositorySystem.java:272)
	at org.apache.maven.project.ProjectModelResolver.resolveModel(ProjectModelResolver.java:192)
	at org.apache.maven.project.ProjectModelResolver.resolveModel(ProjectModelResolver.java:242)
	at org.apache.maven.model.building.DefaultModelBuilder.readParentExternally(DefaultModelBuilder.java:1150)
	at org.apache.maven.model.building.DefaultModelBuilder.readParent(DefaultModelBuilder.java:916)
	at org.apache.maven.model.building.DefaultModelBuilder.build(DefaultModelBuilder.java:361)
	at org.apache.maven.model.building.DefaultModelBuilder.build(DefaultModelBuilder.java:267)
	at org.apache.maven.project.DefaultProjectBuilder.build(DefaultProjectBuilder.java:173)
	at org.apache.maven.project.DefaultProjectBuilder.build(DefaultProjectBuilder.java:137)
	at org.eclipse.lemminx.extensions.maven.MavenProjectCache.parseAndCache(MavenProjectCache.java:132)
	at org.eclipse.lemminx.extensions.maven.MavenProjectCache.check(MavenProjectCache.java:106)
	at org.eclipse.lemminx.extensions.maven.MavenProjectCache.getProblemsFor(MavenProjectCache.java:99)
	at org.eclipse.lemminx.extensions.maven.participants.diagnostics.MavenDiagnosticParticipant.doDiagnostics(MavenDiagnosticParticipant.java:56)
	at org.eclipse.lemminx.services.XMLDiagnostics.doExtensionsDiagnostics(XMLDiagnostics.java:67)
	at org.eclipse.lemminx.services.XMLDiagnostics.doDiagnostics(XMLDiagnostics.java:49)
	at org.eclipse.lemminx.services.XMLLanguageService.doDiagnostics(XMLLanguageService.java:172)
	at org.eclipse.lemminx.extensions.maven.MavenProjectCacheTest.testAddFolders_didChangeWorkspaceFolders(MavenProjectCacheTest.java:111)

Signed-off-by: Victor Rubezhny <vrubezhny@redhat.com>