### PR TITLE
Fix ParticipantUtils.resolveValueWithProperties() method

### DIFF
--- a/lemminx-maven/src/main/java/org/eclipse/lemminx/extensions/maven/utils/DOMUtils.java
+++ b/lemminx-maven/src/main/java/org/eclipse/lemminx/extensions/maven/utils/DOMUtils.java
@@ -28,18 +28,15 @@ public class DOMUtils {
 		if (localName == null || request == null) {
 			return null;
 		}
-		DOMNode pluginNode = request.getNode();
-		try {
-			while (!localName.equals(pluginNode.getLocalName())) {
-				pluginNode = pluginNode.getParentNode();
-			}
-		} catch (NullPointerException e) {
-			return null;
-		}
 
-		if (localName.equals(pluginNode.getLocalName())) {
-			return pluginNode;
+		DOMNode pluginNode = request.getNode();
+		while (pluginNode != null) {
+			if (localName.equals(pluginNode.getLocalName())) {
+				return pluginNode;
+			}
+			pluginNode = pluginNode.getParentNode();
 		}
+		
 		return null;
 	}
 	
@@ -51,9 +48,9 @@ public class DOMUtils {
 		}
 		while (!nodes.isEmpty()) {
 			DOMNode node = nodes.pop();
-				if (node.getLocalName() != null && node.getLocalName().equals(localName)) {
-					foundNodes.add(node);
-				}
+			if (node.getLocalName() != null && node.getLocalName().equals(localName)) {
+				foundNodes.add(node);
+			}
 			if (node.hasChildNodes()) {
 				for (DOMNode childNode : node.getChildren()) {
 					nodes.push(childNode);
@@ -108,19 +105,19 @@ public class DOMUtils {
 		if (parentName == null || request == null) {
 			return null;
 		}
+		
 		DOMNode parentNode = request.getNode().getParentNode();
-		DOMNode ancestorNode = parentNode;
-		try {
-			while (!parentName.equals(parentNode.getLocalName())) {
-				ancestorNode = parentNode;
-				parentNode = parentNode.getParentNode();
-			}
-		} catch (NullPointerException e) {
+		if (parentNode == null) {
 			return null;
 		}
-
-		if (parentName.equals(parentNode.getLocalName())) {
-			return ancestorNode;
+		
+		DOMNode ancestorNode = parentNode;
+		while(parentNode != null) {
+			if (parentName.equals(parentNode.getLocalName())) {
+				return ancestorNode;
+			}
+			ancestorNode = parentNode;
+			parentNode = parentNode.getParentNode();
 		}
 		return null;
 	}

--- a/lemminx-maven/src/main/java/org/eclipse/lemminx/extensions/maven/utils/ParticipantUtils.java
+++ b/lemminx-maven/src/main/java/org/eclipse/lemminx/extensions/maven/utils/ParticipantUtils.java
@@ -15,6 +15,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.Properties;
 import java.util.Map.Entry;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 
 import org.apache.commons.lang3.Validate;
 import org.apache.maven.model.Dependency;
@@ -37,6 +39,8 @@ import org.eclipse.lemminx.utils.XMLPositionUtility;
 import org.eclipse.lsp4j.Range;
 
 public class ParticipantUtils {
+	private static final Logger LOGGER = Logger.getLogger(ParticipantUtils.class.getName());
+
 	private static Properties environmentProperties = null;
 	
 	public static Properties getEnvironmentProperties() {
@@ -95,6 +99,9 @@ public class ParticipantUtils {
 			}
 		} catch (ArtifactResolutionException | ComponentLookupException e) {
 			// can happen
+			LOGGER.log(Level.FINEST, e.getMessage(), e);
+		} catch (Exception e) {
+			LOGGER.log(Level.SEVERE, e.getMessage(), e);
 		}
 		return null;
 	}
@@ -164,6 +171,7 @@ public class ParticipantUtils {
 		int start = 0;
 		while((index = value.indexOf("${", start)) != -1 && 
 				(closeIndex = value.indexOf("}", start)) != -1) {
+			sb.append(value.substring(start, index));
 			String propertyName = value.substring(index + 2, closeIndex);
 			String propertyValue = properties.get(propertyName);
 			if (propertyValue != null) {

--- a/lemminx-maven/src/test/java/org/eclipse/lemminx/extensions/maven/participants/SimpleModelTest.java
+++ b/lemminx-maven/src/test/java/org/eclipse/lemminx/extensions/maven/participants/SimpleModelTest.java
@@ -187,7 +187,7 @@ public class SimpleModelTest {
 		Hover hover = languageService.doHover(document, new Position(15, 20), new SharedSettings());
  		assertTrue((((MarkupContent) hover.getContents().getRight()).getValue().contains("$")));
 
- 		hover = languageService.doHover(document, new Position(15, 35), new SharedSettings());
+ 		hover = languageService.doHover(document, new Position(15, 40), new SharedSettings());
  		assertTrue((((MarkupContent) hover.getContents().getRight()).getValue().contains("0.0.1-SNAPSHOT")));
 
  		hover = languageService.doHover(document, new Position(15, 13), new SharedSettings());

--- a/lemminx-maven/src/test/java/org/eclipse/lemminx/extensions/maven/participants/hover/DownloadArtifactsTest.java
+++ b/lemminx-maven/src/test/java/org/eclipse/lemminx/extensions/maven/participants/hover/DownloadArtifactsTest.java
@@ -16,6 +16,7 @@ import java.io.IOException;
 import java.net.URISyntaxException;
 import java.util.Properties;
 import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
 
 import org.eclipse.lemminx.dom.DOMDocument;
 import org.eclipse.lemminx.extensions.maven.MavenLemminxExtension;
@@ -57,7 +58,7 @@ public class DownloadArtifactsTest {
 	}
 
 	@Test
-	@Timeout(15000)
+	@Timeout(value = 60, unit = TimeUnit.SECONDS)
 	public void testDownloadArtifactOnHover()
 			throws IOException, InterruptedException, ExecutionException, URISyntaxException {
 		languageService.initializeIfNeeded();

--- a/lemminx-maven/src/test/java/org/eclipse/lemminx/extensions/maven/utils/ParticipantUtilsTest.java
+++ b/lemminx-maven/src/test/java/org/eclipse/lemminx/extensions/maven/utils/ParticipantUtilsTest.java
@@ -1,0 +1,76 @@
+/*******************************************************************************
+ * Copyright (c) 2022 Red Hat Inc. and others.
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+package org.eclipse.lemminx.extensions.maven.utils;
+
+import static org.eclipse.lemminx.extensions.maven.DOMConstants.GROUP_ID_ELT;
+import static org.eclipse.lemminx.extensions.maven.DOMConstants.DEPENDENCY_ELT;
+import static org.eclipse.lemminx.extensions.maven.utils.MavenLemminxTestsUtils.createDOMDocument;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.IOException;
+import java.net.URISyntaxException;
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.concurrent.ExecutionException;
+
+import org.apache.maven.project.MavenProject;
+import org.eclipse.lemminx.dom.DOMDocument;
+import org.eclipse.lemminx.dom.DOMNode;
+import org.eclipse.lemminx.extensions.maven.MavenLemminxExtension;
+import org.eclipse.lemminx.extensions.maven.MavenProjectCache;
+import org.eclipse.lemminx.extensions.maven.NoMavenCentralExtension;
+import org.eclipse.lemminx.services.XMLLanguageService;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+@ExtendWith(NoMavenCentralExtension.class)
+public class ParticipantUtilsTest {
+	private XMLLanguageService languageService;
+
+	@BeforeEach
+	public void setUp() throws IOException {
+		languageService = new XMLLanguageService();
+	}
+
+	@AfterEach
+	public void tearDown() throws InterruptedException, ExecutionException {
+		languageService.dispose();
+		languageService = null;
+	}
+
+	@Test
+	public void testResolveValueWithProperties() throws IOException, URISyntaxException {
+		DOMDocument document = createDOMDocument("/pom-with-properties.xml", languageService);
+		MavenLemminxExtension plugin = new MavenLemminxExtension();
+		MavenProjectCache cache = plugin.getProjectCache();
+		MavenProject project = cache.getLastSuccessfulMavenProject(document);
+		assertNotNull(project);
+
+		List<DOMNode> dependencyNodes = DOMUtils.findNodesByLocalName(document, DEPENDENCY_ELT);
+		Optional<DOMNode> groupIdNode = dependencyNodes.stream().filter(DOMNode::isElement)
+				.flatMap(node -> node.getChildren().stream())
+				.filter(node -> GROUP_ID_ELT.equals(node.getLocalName())).findFirst();
+		assertFalse(groupIdNode.isEmpty(), "groupID node not found");
+
+		Optional<String> groupId = groupIdNode.get().getChildren().stream().map(DOMNode::getTextContent)
+						.filter(Objects::nonNull).map(String::trim).filter(s -> !s.isEmpty()).findFirst();
+		assertTrue(groupId.isPresent(), "groupId value doesn't contain a property");
+
+		String value =  groupId.get();
+		String resolvedValue = ParticipantUtils.resolveValueWithProperties(project, value);
+		assertTrue(value.contains("${"), "groupId value doesn't contain a property");
+		assertEquals(resolvedValue, "org.$.test.0.0.1-SNAPSHOT");
+	}
+}

--- a/lemminx-maven/src/test/resources/pom-with-properties.xml
+++ b/lemminx-maven/src/test/resources/pom-with-properties.xml
@@ -13,7 +13,7 @@
 	</properties>
 	<dependencies>
 		<dependency>
-			<groupId>org.${myProperty}.${project.version}</groupId>
+			<groupId>org.${myProperty}.test.${project.version}</groupId>
 		</dependency>
 	</dependencies>
 </project>


### PR DESCRIPTION
The method skips text value before and between the ptoperty variables, if any. JUnit test is added for the issue.
Some code polishing and logging.