### PR TITLE
Exclude aether-api and aether-util for zip-with-dependencies package

### DIFF
--- a/lemminx-maven/pom.xml
+++ b/lemminx-maven/pom.xml
@@ -131,14 +131,22 @@
 			<scope>compile</scope>
 		</dependency>
 		<dependency>
-			<groupId>org.eclipse.aether</groupId>
-			<artifactId>aether-connector-basic</artifactId>
-			<version>1.1.0</version>
-		</dependency>
-		<dependency>
 			<groupId>io.takari.aether</groupId>
 			<artifactId>aether-connector-okhttp</artifactId>
 			<version>0.17.8</version>
+                        <!-- Parts of these got merged into maven-resolver-api and would cause conflicts if on the classpath
+                             See https://github.com/eclipse/lemminx-maven/issues/360
+                        -->
+			<exclusions>
+				<exclusion>
+					<groupId>org.eclipse.aether</groupId>
+					<artifactId>aether-api</artifactId>
+				</exclusion>
+				<exclusion>
+					<groupId>org.eclipse.aether</groupId>
+					<artifactId>aether-util</artifactId>
+				</exclusion>
+			</exclusions>
 		</dependency>
 		<dependency>
 			<groupId>org.apache.maven.wagon</groupId>


### PR DESCRIPTION
I'm not sure why, but having these jars in the classpath lead to
`NoSuchMethodError` exceptions when triggering completion.

Fixes https://github.com/eclipse/lemminx-maven/issues/360
