### PR TITLE
Add Code Actions for Parent Version/Group ID removal 

### DIFF
--- a/lemminx-maven/src/main/java/org/eclipse/lemminx/extensions/maven/MavenLemminxExtension.java
+++ b/lemminx-maven/src/main/java/org/eclipse/lemminx/extensions/maven/MavenLemminxExtension.java
@@ -64,6 +64,7 @@ import org.codehaus.plexus.component.repository.exception.ComponentLookupExcepti
 import org.eclipse.aether.RepositorySystemSession;
 import org.eclipse.aether.repository.WorkspaceReader;
 import org.eclipse.lemminx.dom.DOMDocument;
+import org.eclipse.lemminx.extensions.maven.participants.codeaction.MavenIdPartRemovalCodeAction;
 import org.eclipse.lemminx.extensions.maven.participants.codeaction.MavenNoGrammarConstraintsCodeAction;
 import org.eclipse.lemminx.extensions.maven.participants.completion.MavenCompletionParticipant;
 import org.eclipse.lemminx.extensions.maven.participants.definition.MavenDefinitionParticipant;
@@ -480,7 +481,8 @@ public class MavenLemminxExtension implements IXMLExtension {
 					return;
 				}
 				codeActionParticipants.add(new MavenNoGrammarConstraintsCodeAction());
-				
+				codeActionParticipants.add(new MavenIdPartRemovalCodeAction());
+
 				codeActionParticipants.stream().forEach(registry::registerCodeActionParticipant);
 			}
 		}

--- a/lemminx-maven/src/main/java/org/eclipse/lemminx/extensions/maven/MavenSyntaxErrorCode.java
+++ b/lemminx-maven/src/main/java/org/eclipse/lemminx/extensions/maven/MavenSyntaxErrorCode.java
@@ -1,0 +1,50 @@
+/*******************************************************************************
+ * Copyright (c) 2023 Red Hat Inc. and others.
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+package org.eclipse.lemminx.extensions.maven;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.eclipse.lemminx.services.extensions.diagnostics.IXMLErrorCode;
+
+public enum MavenSyntaxErrorCode implements IXMLErrorCode {
+	DuplicationOfParentGroupId,
+	DuplicationOfParentVersion;
+
+	private final String code;
+
+	private MavenSyntaxErrorCode() {
+		this(null);
+	}
+
+	private MavenSyntaxErrorCode(String code) {
+		this.code = code;
+	}
+
+	@Override
+	public String getCode() {
+		if (code == null) {
+			return name();
+		}
+		return code;
+	}
+	
+	private final static Map<String, MavenSyntaxErrorCode> codes;
+
+	static {
+		codes = new HashMap<>();
+		for (MavenSyntaxErrorCode errorCode : values()) {
+			codes.put(errorCode.getCode(), errorCode);
+		}
+	}
+
+	public static MavenSyntaxErrorCode get(String name) {
+		return codes.get(name);
+	}
+}

--- a/lemminx-maven/src/main/java/org/eclipse/lemminx/extensions/maven/participants/codeaction/MavenIdPartRemovalCodeAction.java
+++ b/lemminx-maven/src/main/java/org/eclipse/lemminx/extensions/maven/participants/codeaction/MavenIdPartRemovalCodeAction.java
@@ -1,0 +1,73 @@
+/*******************************************************************************
+ * Copyright (c) 2023 Red Hat Inc. and others.
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+package org.eclipse.lemminx.extensions.maven.participants.codeaction;
+
+import static org.eclipse.lemminx.extensions.maven.DOMConstants.GROUP_ID_ELT;
+import static org.eclipse.lemminx.extensions.maven.DOMConstants.PROJECT_ELT;
+import static org.eclipse.lemminx.extensions.maven.DOMConstants.VERSION_ELT;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+import org.eclipse.lemminx.commons.BadLocationException;
+import org.eclipse.lemminx.commons.CodeActionFactory;
+import org.eclipse.lemminx.commons.TextDocument;
+import org.eclipse.lemminx.dom.DOMDocument;
+import org.eclipse.lemminx.dom.DOMElement;
+import org.eclipse.lemminx.extensions.maven.MavenSyntaxErrorCode;
+import org.eclipse.lemminx.extensions.maven.utils.DOMUtils;
+import org.eclipse.lemminx.extensions.maven.utils.ParticipantUtils;
+import org.eclipse.lemminx.services.extensions.codeaction.ICodeActionParticipant;
+import org.eclipse.lemminx.services.extensions.codeaction.ICodeActionRequest;
+
+import org.eclipse.lsp4j.CodeAction;
+import org.eclipse.lsp4j.Diagnostic;
+import org.eclipse.lsp4j.Range;
+import org.eclipse.lsp4j.jsonrpc.CancelChecker;
+
+public class MavenIdPartRemovalCodeAction implements ICodeActionParticipant {
+	private static final Logger LOGGER = Logger.getLogger(MavenIdPartRemovalCodeAction.class.getName());
+
+	public MavenIdPartRemovalCodeAction() {
+	}
+	
+	@Override
+	public void doCodeAction(ICodeActionRequest request, List<CodeAction> codeActions, CancelChecker cancelChecker) {
+		Diagnostic diagnostic = request.getDiagnostic();
+
+		boolean isVersion;
+		if (ParticipantUtils.match(diagnostic, MavenSyntaxErrorCode.DuplicationOfParentGroupId.getCode())) {
+			isVersion = false;
+		} else if (ParticipantUtils.match(diagnostic, MavenSyntaxErrorCode.DuplicationOfParentVersion.getCode())) {
+			isVersion = true;
+		} else {
+			// Code is not supported by this Code Action
+			return;
+		}
+
+		DOMDocument document = request.getDocument();
+		Optional<DOMElement> project = DOMUtils.findChildElement(document, PROJECT_ELT);
+		project.flatMap(p ->DOMUtils.findChildElement(project.get(), isVersion ? VERSION_ELT : GROUP_ID_ELT))
+			.filter(DOMElement.class::isInstance).map(DOMElement.class::cast).ifPresent(v -> {
+				TextDocument textDocument = document.getTextDocument();
+				try {
+					Range valueRange = new Range(textDocument.positionAt(v.getStart()), textDocument.positionAt(v.getEnd()));
+					// It removes the current definition to rely on value inherited from parent
+					CodeAction addSchemaAction = CodeActionFactory.remove(
+							isVersion ? "Remove version declaration" : "Remove groupId declaration",
+							valueRange, document.getTextDocument(),  diagnostic);
+					codeActions.add(addSchemaAction);
+				} catch (BadLocationException e) {
+					LOGGER.log(Level.SEVERE, "Unable to remove specified element", e);
+				}
+			});
+	}
+}

--- a/lemminx-maven/src/main/java/org/eclipse/lemminx/extensions/maven/participants/diagnostics/MavenDiagnosticParticipant.java
+++ b/lemminx-maven/src/main/java/org/eclipse/lemminx/extensions/maven/participants/diagnostics/MavenDiagnosticParticipant.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019-2021 Red Hat Inc. and others.
+ * Copyright (c) 2019-2023 Red Hat Inc. and others.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/
@@ -10,6 +10,7 @@ package org.eclipse.lemminx.extensions.maven.participants.diagnostics;
 
 import static org.eclipse.lemminx.extensions.maven.DOMConstants.CONFIGURATION_ELT;
 import static org.eclipse.lemminx.extensions.maven.DOMConstants.GOAL_ELT;
+import static org.eclipse.lemminx.extensions.maven.DOMConstants.PROJECT_ELT;
 
 import java.util.ArrayDeque;
 import java.util.Collection;
@@ -61,6 +62,16 @@ public class MavenDiagnosticParticipant implements IDiagnosticsParticipant {
 		DOMElement documentElement = xmlDocument.getDocumentElement();
 		Map<String, Function<DiagnosticRequest, Optional<List<Diagnostic>>>> tagDiagnostics = configureDiagnosticFunctions();
 
+		// Validate project element
+		if (PROJECT_ELT.equals(documentElement.getNodeName())) {
+			ProjectValidator projectValidator = new ProjectValidator(plugin);
+			projectValidator.validateProject(new DiagnosticRequest(documentElement, xmlDocument))
+				.ifPresent(diagnosticList ->{
+						diagnostics.addAll(diagnosticList.stream()
+							.filter(diagnostic -> !diagnostics.contains(diagnostic)).collect(Collectors.toList()));
+					});
+		}
+		
 		Deque<DOMNode> nodes = new ArrayDeque<>();
 		for (DOMNode node : documentElement.getChildren()) {
 			nodes.push(node);

--- a/lemminx-maven/src/main/java/org/eclipse/lemminx/extensions/maven/participants/diagnostics/ProjectValidator.java
+++ b/lemminx-maven/src/main/java/org/eclipse/lemminx/extensions/maven/participants/diagnostics/ProjectValidator.java
@@ -1,0 +1,145 @@
+/*******************************************************************************
+ * Copyright (c) 2023 Red Hat Inc. and others.
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+package org.eclipse.lemminx.extensions.maven.participants.diagnostics;
+
+import static org.eclipse.lemminx.extensions.maven.DOMConstants.GROUP_ID_ELT;
+import static org.eclipse.lemminx.extensions.maven.DOMConstants.PARENT_ELT;
+import static org.eclipse.lemminx.extensions.maven.DOMConstants.VERSION_ELT;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import java.util.logging.Logger;
+
+import org.apache.maven.project.MavenProject;
+
+import org.eclipse.lemminx.dom.DOMDocument;
+import org.eclipse.lemminx.dom.DOMElement;
+import org.eclipse.lemminx.dom.DOMNode;
+import org.eclipse.lemminx.extensions.maven.MavenSyntaxErrorCode;
+import org.eclipse.lemminx.extensions.maven.MavenLemminxExtension;
+import org.eclipse.lemminx.extensions.maven.utils.DOMUtils;
+import org.eclipse.lemminx.utils.XMLPositionUtility;
+import org.eclipse.lsp4j.Diagnostic;
+import org.eclipse.lsp4j.DiagnosticSeverity;
+
+public class ProjectValidator {
+	private static final Logger LOGGER = Logger.getLogger(ProjectValidator.class.getName());
+
+	private MavenLemminxExtension plugin;
+
+	public ProjectValidator(MavenLemminxExtension plugin) {
+		this.plugin = plugin;
+	}
+
+	/**
+	 * Validates if parent groupId and/or version match the project's ones
+	 * 
+	 * @param diagnosticRequest
+	 * @return
+	 */
+	public Optional<List<Diagnostic>> validateProject(DiagnosticRequest diagnosticRequest) {
+		DOMNode node = diagnosticRequest.getNode();
+		if (node == null) {
+			return Optional.empty();
+		}
+
+		MavenProject project = plugin.getProjectCache().getLastSuccessfulMavenProject(diagnosticRequest.getXMLDocument());
+		List<Diagnostic> diagnostics = new ArrayList<>();
+		diagnostics.addAll(validateParentMatchingGroupIdVersion(diagnosticRequest).get());
+		if (project != null) {
+			diagnostics.addAll(validateManagedDependencies(diagnosticRequest, project).get());
+			diagnostics.addAll(validateManagedPlugins(diagnosticRequest, project).get());
+		}
+		return Optional.of(diagnostics);
+	}
+	
+	/**
+	 * Validates if parent groupId and/or version match the project's ones
+	 * 
+	 * @param diagnosticRequest
+	 * @return
+	 */
+	private Optional<List<Diagnostic>> validateParentMatchingGroupIdVersion(DiagnosticRequest diagnosticRequest) {
+		DOMNode node = diagnosticRequest.getNode();
+		if (node == null) {
+			return Optional.empty();
+		}
+
+		List<Diagnostic> diagnostics = new ArrayList<>();
+		Optional<DOMElement> parent = DOMUtils.findChildElement(node, PARENT_ELT);
+		parent.ifPresent(p -> {
+			Optional<DOMElement> groupId = DOMUtils.findChildElement(node, GROUP_ID_ELT);
+		    groupId.ifPresent(g -> {
+					//now compare the values of parent and project groupid..
+					String parentString = DOMUtils.findChildElementText(p, GROUP_ID_ELT).orElse(null);
+					String childString = DOMUtils.findElementText(g).orElse(null);
+					if(parentString != null && parentString.equals(childString)) {
+						DOMDocument xmlDocument = diagnosticRequest.getXMLDocument();
+						diagnostics.add(new Diagnostic(
+								XMLPositionUtility.createRange(g.getStartTagCloseOffset() + 1, 
+										g.getEndTagOpenOffset(), xmlDocument), 
+								"GroupId is duplicate of parent groupId",
+								DiagnosticSeverity.Warning,
+								xmlDocument.getDocumentURI(), 
+								MavenSyntaxErrorCode.DuplicationOfParentGroupId.getCode()));
+					}
+			    });
+
+		    Optional<DOMElement> version = DOMUtils.findChildElement(node, VERSION_ELT);
+		    version.ifPresent(v -> {
+					//now compare the values of parent and project version..
+					String parentString = DOMUtils.findChildElementText(p, VERSION_ELT).orElse(null);
+					String childString = DOMUtils.findElementText(v).orElse(null);
+					if(parentString != null && parentString.equals(childString)) {
+						DOMDocument xmlDocument = diagnosticRequest.getXMLDocument();
+						diagnostics.add(new Diagnostic(
+								XMLPositionUtility.createRange(v.getStartTagCloseOffset() + 1, 
+										v.getEndTagOpenOffset(), xmlDocument), 
+								"Version is duplicate of parent version",
+								DiagnosticSeverity.Warning,
+								xmlDocument.getDocumentURI(), 
+								MavenSyntaxErrorCode.DuplicationOfParentVersion.getCode()));
+					}
+			    });
+		});
+
+		return Optional.of(diagnostics);
+	}
+	    
+	/**
+	 * TODO: Validates if a dependency version duplicates or overrides a managed dependency version
+	 * 
+	 * @param diagnosticRequest
+	 * @return
+	 */
+	private Optional<List<Diagnostic>> validateManagedDependencies(DiagnosticRequest diagnosticRequest, MavenProject mavenProject) {
+		DOMNode node = diagnosticRequest.getNode();
+		if (node == null) {
+			return Optional.empty();
+		}
+
+		List<Diagnostic> diagnostics = new ArrayList<>();
+		return Optional.of(diagnostics);
+	}
+
+	// TODO: Move here the validation from
+	// org.eclipse.m2e.core.ui.internal.markers.MarkerLocationService.checkManagedPlugins(IMavenMarkerManager,
+	// Element, IResource, MavenProject, String, IStructuredDocument)
+	// checkManagedPlugins(mavenMarkerManager, root, pomFile, mavenProject, type,
+	// document);
+	private Optional<List<Diagnostic>> validateManagedPlugins(DiagnosticRequest diagnosticRequest, MavenProject project) {
+		DOMNode node = diagnosticRequest.getNode();
+		if (node == null) {
+			return Optional.empty();
+		}
+		List<Diagnostic> diagnostics = new ArrayList<>();
+		return Optional.of(diagnostics);
+	}
+}

--- a/lemminx-maven/src/main/java/org/eclipse/lemminx/extensions/maven/utils/DOMUtils.java
+++ b/lemminx-maven/src/main/java/org/eclipse/lemminx/extensions/maven/utils/DOMUtils.java
@@ -13,6 +13,7 @@ import java.util.ArrayList;
 import java.util.Deque;
 import java.util.List;
 import java.util.Optional;
+import java.util.stream.Collectors;
 
 import org.eclipse.lemminx.commons.BadLocationException;
 import org.eclipse.lemminx.dom.DOMDocument;
@@ -79,8 +80,8 @@ public class DOMUtils {
 				.filter(DOMElement.class::isInstance).map(DOMElement.class::cast).findAny();
 	}
 
-	public static Optional<String> findChildElementText(DOMNode pluginNode, final String elementName) {
-		return findChildElement(pluginNode, elementName) //
+	public static Optional<String> findChildElementText(DOMNode rootNode, final String elementName) {
+		return findChildElement(rootNode, elementName) //
 				.stream() //
 				.flatMap(element -> element.getChildren().stream()) //
 				.filter(Text.class::isInstance)
@@ -88,7 +89,15 @@ public class DOMUtils {
 				.map(Text::getData)
 				.findFirst();
 	}
-
+	
+	public static Optional<String> findElementText(DOMElement element) {
+		return element.getChildren().stream() //
+				.filter(Text.class::isInstance)
+				.map(Text.class::cast)
+				.map(Text::getData)
+				.findFirst();
+	}
+	
 	public static String getOneLevelIndent(ICompletionRequest request) throws BadLocationException {
 		String oneLevelIndent = request.getLineIndentInfo().getWhitespacesIndent();
 		int nodeDepth = 0;

--- a/lemminx-maven/src/test/java/org/eclipse/lemminx/extensions/maven/participants/codeaction/MavenCodeActionParticipantTest.java
+++ b/lemminx-maven/src/test/java/org/eclipse/lemminx/extensions/maven/participants/codeaction/MavenCodeActionParticipantTest.java
@@ -8,41 +8,35 @@
  *******************************************************************************/
 package org.eclipse.lemminx.extensions.maven.participants.codeaction;
 
+import static org.eclipse.lemminx.XMLAssert.assertDiagnostics;
 import static org.eclipse.lemminx.XMLAssert.ca;
 import static org.eclipse.lemminx.XMLAssert.d;
 import static org.eclipse.lemminx.XMLAssert.teOp;
+import static org.eclipse.lemminx.XMLAssert.testCodeActionsFor;
 
-import static org.junit.jupiter.api.Assertions.assertIterableEquals;
+import static org.eclipse.lemminx.extensions.maven.utils.MavenLemminxTestsUtils.createDOMDocument;
 
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.stream.Collectors;
 
-import org.eclipse.lemminx.XMLAssert;
 import org.eclipse.lemminx.XMLAssert.SettingsSaveContext;
 import org.eclipse.lemminx.commons.BadLocationException;
-import org.eclipse.lemminx.commons.TextDocument;
 import org.eclipse.lemminx.dom.DOMDocument;
-import org.eclipse.lemminx.dom.DOMParser;
 import org.eclipse.lemminx.extensions.contentmodel.participants.XMLSyntaxErrorCode;
 import org.eclipse.lemminx.extensions.contentmodel.settings.ContentModelSettings;
 import org.eclipse.lemminx.extensions.contentmodel.settings.XMLValidationRootSettings;
 import org.eclipse.lemminx.extensions.maven.NoMavenCentralExtension;
 import org.eclipse.lemminx.services.XMLLanguageService;
 import org.eclipse.lemminx.settings.SharedSettings;
-import org.eclipse.lemminx.utils.StringUtils;
 import org.eclipse.lsp4j.CodeAction;
-import org.eclipse.lsp4j.CodeActionContext;
 import org.eclipse.lsp4j.Diagnostic;
-import org.eclipse.lsp4j.DiagnosticRelatedInformation;
 
-import org.eclipse.lsp4j.Position;
-import org.eclipse.lsp4j.Range;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 
-import com.google.gson.Gson;
+import org.eclipse.lemminx.extensions.maven.MavenSyntaxErrorCode;
 
 @ExtendWith(NoMavenCentralExtension.class)
 public class MavenCodeActionParticipantTest {
@@ -52,160 +46,82 @@ public class MavenCodeActionParticipantTest {
 	// EDITOR_HINT_MISSING_SCHEMA == NoGrammarConstraints
 	@Test
 	public void testCodeActionsForNoGrammarConstraints() throws Exception {
-		String pom = """
-			<?xml version="1.0" encoding="UTF-8"?>
-			<project>
-			  <modelVersion>4.0.0</modelVersion>
-			  <artifactId>just-a-pom</artifactId>
-			  <groupId>com.datho7561</groupId>
-			  <version>0.1.0</version>
-			  <dependencies>
-			    <dependency>
-			      <groupId>com.fasterxml.jackson.core</groupId>
-			      <artifactId>jackson-core</artifactId>
-			      <version>2.11.3</version>
-			    </dependency>
-			    maven-core
-			  </dependencies>
-			</project>
-				""";
-
-		// Test for expected diagnostics is returned
-		Diagnostic expected = d(1, 1, 1, 8, 
+		DOMDocument xmlDocument = createDOMDocument("/codeactions-test/pom-no-grammar-constraints.xml", xmlLanguageService);
+		
+		// Test diagnostic and code action for absent grammar constraints
+		Diagnostic expectedDiagnostic = d(1, 1, 1, 8, 
 				XMLSyntaxErrorCode.NoGrammarConstraints,
 				"No grammar constraints (DTD or XML Schema).");
-		
-		ContentModelSettings settings = new ContentModelSettings();
-		settings.setUseCache(false);
-		XMLValidationRootSettings problems = new XMLValidationRootSettings();
-		// Do not ignore "No-grammar" errors
-		settings.setValidation(problems);
-
-		TextDocument document = new TextDocument(pom, "pom.xml");
-		DOMDocument xmlDocument = DOMParser.getInstance().parse(document,
-				xmlLanguageService.getResolverExtensionManager());
-		xmlLanguageService.setDocumentProvider((uri) -> xmlDocument);
-
-		xmlLanguageService.doSave(new SettingsSaveContext(settings));
-		
-		List<Diagnostic> actual = xmlLanguageService.doDiagnostics(xmlDocument, settings.getValidation(),
-				Collections.emptyMap(), () -> {
-				});
-
-//		if (expected == null) {
-//			assertTrue(actual.isEmpty());
-//			return;
-//		}
-		assertDiagnostics(actual, Arrays.asList(expected), true);		
-
-		// Test for expected code action is returned
-		expected = d(1, 8, 1, 8, 
-				XMLSyntaxErrorCode.NoGrammarConstraints,
-				"No grammar constraints (DTD or XML Schema).");
-		
-		testCodeActionsFor(pom, expected, (String) null, "pom.xml", sharedSettings, xmlLanguageService, -1,
-				ca(expected, teOp("pom.xml", 1, 8, 1, 8, MavenNoGrammarConstraintsCodeAction.XSI_VALUE)));
+		CodeAction expectedCodeAction = ca(expectedDiagnostic, teOp("pom.xml", 1, 8, 1, 8, MavenNoGrammarConstraintsCodeAction.XSI_VALUE));
+		testCodeAction(xmlDocument,false, expectedDiagnostic, expectedCodeAction);
 	}
 	
 //	The following org.eclipse.m2e.core.internal.IMavenConstants hint quickfixes are to be moved to LemMinX-Maven:
 //
-//		EDITOR_HINT_PARENT_VERSION
-//		EDITOR_HINT_PARENT_GROUP_ID
-//		EDITOR_HINT_MANAGED_DEPENDENCY_OVERRIDE
-//		EDITOR_HINT_MANAGED_PLUGIN_OVERRIDE
-//		EDITOR_HINT_CONFLICTING_LIFECYCLEMAPPING
-//		EDITOR_HINT_NOT_COVERED_MOJO_EXECUTION
-//		EDITOR_HINT_MISSING_CONFIGURATOR
-//		EDITOR_HINT_IMPLICIT_LIFECYCLEMAPPING
-	
-	public static void assertDiagnostics(List<Diagnostic> actual, List<Diagnostic> expected, boolean filter) {
-		List<Diagnostic> received = actual;
-		final boolean filterMessage;
-		if (expected != null && !expected.isEmpty() && !StringUtils.isEmpty(expected.get(0).getMessage())) {
-			filterMessage = true;
-		} else {
-			filterMessage = false;
-		}
-		if (filter) {
-			received = actual.stream().map(d -> {
-				Diagnostic simpler = new Diagnostic(d.getRange(), "");
-				if (d.getCode() != null && !StringUtils.isEmpty(d.getCode().getLeft())) {
-					simpler.setCode(d.getCode());
-				}
-				if (filterMessage) {
-					simpler.setMessage(d.getMessage());
-				}
-				return simpler;
-			}).collect(Collectors.toList());
-		}
-		// Don't compare message of diagnosticRelatedInformation
-		for (Diagnostic diagnostic : received) {
-			List<DiagnosticRelatedInformation> diagnosticRelatedInformations = diagnostic.getRelatedInformation();
-			if (diagnosticRelatedInformations != null) {
-				for (DiagnosticRelatedInformation diagnosticRelatedInformation : diagnosticRelatedInformations) {
-					diagnosticRelatedInformation.setMessage("");
-				}
-			}
-		}
-		assertIterableEquals(expected, received, "Unexpected diagnostics:\n" + actual);
+//	EDITOR_HINT_PARENT_VERSION (from m2e.ui)
+	@Test
+	public void testCodeActionsForParentVersionRemoval() throws Exception {
+		DOMDocument xmlDocument = createDOMDocument("/codeactions-test/pom-duplication-of-version.xml", xmlLanguageService);
+
+		// Test diagnostic and code action for duplicated parent version
+		Diagnostic expectedDiagnostic = d(11, 11, 11, 16, 
+				MavenSyntaxErrorCode.DuplicationOfParentVersion,
+				"Version is duplicate of parent version");
+		CodeAction expectedCodeAction = ca(expectedDiagnostic, teOp("pom.xml", 11, 2, 11, 26, ""));
+		testCodeAction(xmlDocument,true, expectedDiagnostic, expectedCodeAction);
+	}
+
+//	EDITOR_HINT_PARENT_GROUP_ID (from m2e.ui)
+	@Test
+	public void testCodeActionsForParentGroupIdRemoval() throws Exception {
+		DOMDocument xmlDocument = createDOMDocument("/codeactions-test/pom-duplication-of-groupid.xml", xmlLanguageService);
+
+		// Test diagnostic and code action for duplicated parent group ID
+		Diagnostic expectedDiagnostic = d(11, 11, 11, 27, 
+				MavenSyntaxErrorCode.DuplicationOfParentGroupId,
+				"GroupId is duplicate of parent groupId");
+		CodeAction expectedCodeAction = ca(expectedDiagnostic, teOp("pom.xml", 11, 2, 11, 37, ""));
+		testCodeAction(xmlDocument,true, expectedDiagnostic, expectedCodeAction);
 	}
 	
-	// Copied from XMLAssert due to the linking problem
-	private static final String FILE_URI = "test.xml";
-	public static List<CodeAction> testCodeActionsFor(String xml, Diagnostic diagnostic, String catalogPath,
-			String fileURI, SharedSettings sharedSettings, XMLLanguageService xmlLanguageService, int index,
-			CodeAction... expected) throws BadLocationException {
-		int offset = xml.indexOf('|');
-		Range range = null;
+//	@TODO: EDITOR_HINT_MANAGED_DEPENDENCY_OVERRIDE (from m2e.ui)
+//	@TODO: EDITOR_HINT_MANAGED_PLUGIN_OVERRIDE (from m2e.ui)
+//	@TODO: EDITOR_HINT_CONFLICTING_LIFECYCLEMAPPING (from m2e.core)
+//	@TODO: EDITOR_HINT_NOT_COVERED_MOJO_EXECUTION (from m2e.core)
+//	@TODO: EDITOR_HINT_MISSING_CONFIGURATOR (from m2e.core)
+//	@TODO: EDITOR_HINT_IMPLICIT_LIFECYCLEMAPPINGEDITOR_HINT_IMPLICIT_LIFECYCLEMAPPING
+	
+	
+	private void testCodeAction(DOMDocument xmlDocument, boolean ignoreNoGrammar, Diagnostic expectedDiagnostic, CodeAction expectedCodeAction) throws BadLocationException {
+		// Test for expected diagnostics is returned
+		ContentModelSettings settings = createContentModelSettings(ignoreNoGrammar);
+		xmlLanguageService.setDocumentProvider((uri) -> xmlDocument);
+		xmlLanguageService.doSave(new SettingsSaveContext(settings));
 
-		if (offset != -1) {
-			xml = xml.substring(0, offset) + xml.substring(offset + 1);
+		List<Diagnostic> actual = xmlLanguageService.doDiagnostics(xmlDocument, settings.getValidation(),
+				Collections.emptyMap(), () -> {
+				}).stream().filter(a -> a.getCode()!= null & a.getCode().getLeft().equals(expectedDiagnostic.getCode().getLeft()))
+				.collect(Collectors.toList());
+//		if (expected == null) {
+//			assertTrue(actual.isEmpty());
+//			return;
+//		}
+		assertDiagnostics(actual, Arrays.asList(expectedDiagnostic), true);		
+
+		// Test for expected code action is returned
+		testCodeActionsFor(xmlDocument.getText(), expectedCodeAction.getDiagnostics().get(0), (String) null, "pom.xml", 
+				sharedSettings, xmlLanguageService, -1, expectedCodeAction);
+	}
+	
+	
+	private static ContentModelSettings  createContentModelSettings(boolean ignoreNoGrammar) {
+		ContentModelSettings settings = new ContentModelSettings();
+		settings.setUseCache(false);
+		XMLValidationRootSettings problems = new XMLValidationRootSettings();
+		if (ignoreNoGrammar) {
+			problems.setNoGrammar("ignore");
 		}
-		TextDocument document = new TextDocument(xml.toString(), fileURI != null ? fileURI : FILE_URI);
-
-		if (offset != -1) {
-			Position position = document.positionAt(offset);
-			range = new Range(position, position);
-		} else {
-			range = diagnostic.getRange();
-		}
-
-		if (xmlLanguageService == null) {
-			xmlLanguageService = new XMLLanguageService();
-		}
-
-		ContentModelSettings cmSettings = new ContentModelSettings();
-		cmSettings.setUseCache(false);
-		if (catalogPath != null) {
-			// Configure XML catalog for XML schema
-			cmSettings.setCatalogs(new String[] { catalogPath });
-		}
-		xmlLanguageService.doSave(new SettingsSaveContext(cmSettings));
-
-		CodeActionContext context = new CodeActionContext();
-		context.setDiagnostics(Arrays.asList(diagnostic));
-		DOMDocument xmlDoc = DOMParser.getInstance().parse(document, xmlLanguageService.getResolverExtensionManager());
-		xmlLanguageService.setDocumentProvider((uri) -> xmlDoc);
-
-		List<CodeAction> actual = xmlLanguageService.doCodeActions(context, range, xmlDoc, sharedSettings, () -> {
-		});
-
-		// Clone
-		// Creating a gson object
-		Gson gson = new Gson();
-		// Converting the list into a json string
-		String jsonstring = gson.toJson(actual);
-
-		// Converting the json string
-		// back into a list
-		CodeAction[] cloned_list = gson.fromJson(jsonstring, CodeAction[].class);
-
-		// Only test the code action at index if a proper index is given
-		if (index >= 0) {
-			XMLAssert.assertCodeActions(Arrays.asList(actual.get(index)), Arrays.asList(expected).get(index));
-			return Arrays.asList(cloned_list);
-		}
-		XMLAssert.assertCodeActions(actual, expected);
-		return Arrays.asList(cloned_list);
+		settings.setValidation(problems);
+		return settings;
 	}
 }

--- a/lemminx-maven/src/test/resources/codeactions-test/parent/pom.xml
+++ b/lemminx-maven/src/test/resources/codeactions-test/parent/pom.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <groupId>org.eclipse.test</groupId>
+  <artifactId>just-a-parent</artifactId>
+  <version>1.0.0</version>
+  <packaging>pom</packaging>
+</project>

--- a/lemminx-maven/src/test/resources/codeactions-test/pom-duplication-of-groupid.xml
+++ b/lemminx-maven/src/test/resources/codeactions-test/pom-duplication-of-groupid.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+     <parent>
+       <groupId>org.eclipse.test</groupId>
+       <artifactId>just-a-parent</artifactId>
+       <version>1.0.0</version>
+       <relativePath>parent/pom.xml</relativePath>
+     </parent>			  
+  <artifactId>just-a-pom</artifactId>
+  <groupId>org.eclipse.test</groupId>
+  <packaging>pom</packaging>
+<!--  <dependencies>
+    <dependency>
+      <groupId>com.fasterxml.jackson.core</groupId>
+      <artifactId>jackson-core</artifactId>
+      <version>2.11.3</version>
+    </dependency>
+  </dependencies> -->
+</project>

--- a/lemminx-maven/src/test/resources/codeactions-test/pom-duplication-of-version.xml
+++ b/lemminx-maven/src/test/resources/codeactions-test/pom-duplication-of-version.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+     <parent>
+       <groupId>org.eclipse.test</groupId>
+       <artifactId>just-a-parent</artifactId>
+       <version>1.0.0</version>
+       <relativePath>parent/pom.xml</relativePath>
+     </parent>			  
+  <artifactId>just-a-pom</artifactId>
+  <version>1.0.0</version>
+  <packaging>pom</packaging>
+<!--  <dependencies>
+    <dependency>
+      <groupId>com.fasterxml.jackson.core</groupId>
+      <artifactId>jackson-core</artifactId>
+      <version>2.11.3</version>
+    </dependency>
+  </dependencies> -->
+</project>

--- a/lemminx-maven/src/test/resources/codeactions-test/pom-no-grammar-constraints.xml
+++ b/lemminx-maven/src/test/resources/codeactions-test/pom-no-grammar-constraints.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project>
+  <modelVersion>4.0.0</modelVersion>
+  <artifactId>just-a-pom</artifactId>
+  <groupId>com.datho7561</groupId>
+  <version>0.1.0</version>
+  <dependencies>
+    <dependency>
+      <groupId>com.fasterxml.jackson.core</groupId>
+      <artifactId>jackson-core</artifactId>
+      <version>2.11.3</version>
+    </dependency>
+  </dependencies>
+</project>


### PR DESCRIPTION
This PR adds Maven project validation for groupId/version element values duplicating the parent groupId/version element values
Also this adds Code Actions for the removal of the duplicating groupId/version elements and according JUnit test cases

Depends on #362