### PR TITLE
[tests] Fix tests failing on long downloading of Maven XSD Schema

### DIFF
--- a/lemminx-maven/src/test/java/org/eclipse/lemminx/extensions/maven/participants/PluginResolutionTest.java
+++ b/lemminx-maven/src/test/java/org/eclipse/lemminx/extensions/maven/participants/PluginResolutionTest.java
@@ -28,6 +28,7 @@ import org.eclipse.lemminx.extensions.contentmodel.settings.XMLValidationSetting
 import org.eclipse.lemminx.extensions.maven.MavenLemminxExtension;
 import org.eclipse.lemminx.extensions.maven.NoMavenCentralExtension;
 import org.eclipse.lemminx.extensions.maven.participants.diagnostics.MavenDiagnosticParticipant;
+import org.eclipse.lemminx.extensions.maven.utils.MavenLemminxTestsUtils;
 import org.eclipse.lemminx.services.XMLLanguageService;
 import org.eclipse.lemminx.settings.SharedSettings;
 import org.eclipse.lsp4j.Diagnostic;
@@ -66,6 +67,7 @@ public class PluginResolutionTest {
 			}
 		}
 		FileUtils.deleteDirectory(initialMavenPluginApiDirectory);
+		MavenLemminxTestsUtils.prefetchDavenXSD();
 	}
 
 	@AfterEach

--- a/lemminx-maven/src/test/java/org/eclipse/lemminx/extensions/maven/participants/SimpleModelTest.java
+++ b/lemminx-maven/src/test/java/org/eclipse/lemminx/extensions/maven/participants/SimpleModelTest.java
@@ -70,6 +70,7 @@ public class SimpleModelTest {
 	@BeforeEach
 	public void setUp() throws IOException {
 		languageService = new XMLLanguageService();
+		MavenLemminxTestsUtils.prefetchDavenXSD();
 	}
 
 	@AfterEach


### PR DESCRIPTION
In order to prevent the appearance of Downloading Operation Information Diagnostic we need the `http(-s)://maven.apache.org/xsd/maven-4.0.0.xsd` schemas to be cached  so it won' t be downloaded during the test