### PR TITLE
Fix BLE In MavenCompletionParticipant.internalCollectRemoteGAVCompletion

### DIFF
--- a/lemminx-maven/src/main/java/org/eclipse/lemminx/extensions/maven/participants/completion/MavenCompletionParticipant.java
+++ b/lemminx-maven/src/main/java/org/eclipse/lemminx/extensions/maven/participants/completion/MavenCompletionParticipant.java
@@ -783,9 +783,9 @@ public class MavenCompletionParticipant extends CompletionParticipantAdapter {
 			return;
 		}
 		DOMDocument doc = request.getXMLDocument();
-
-		Range range = XMLPositionUtility.createRange(node.getStartTagCloseOffset() + 1, node.getEndTagOpenOffset(),
-				doc);
+		int startTagCloseOffset = node.getStartTagCloseOffset() >= 0 ? node.getStartTagCloseOffset() : 0;
+		int endTagOpenOffset = node.getEndTagOpenOffset() >= 0 ? node.getEndTagOpenOffset() : request.getOffset();
+		Range range = XMLPositionUtility.createRange(startTagCloseOffset + 1, endTagOpenOffset, doc);
 		Set<CompletionItem> updateItems = Collections.synchronizedSet(new HashSet<>(1));
 		final CompletionItem updatingItem = new CompletionItem(WAITING_LABEL);
 		updatingItem.setPreselect(false);


### PR DESCRIPTION
```
SEVERE: While creating Range the Offset was a BadLocation
org.eclipse.lemminx.commons.BadLocationException: Negative offset : -1
	at org.eclipse.lemminx.commons.ListLineTracker.getLineNumberOfOffset(ListLineTracker.java:162)
	at org.eclipse.lemminx.commons.ListLineTracker.getPositionAt(ListLineTracker.java:94)
	at org.eclipse.lemminx.commons.TextDocument.positionAt(TextDocument.java:66)
	at org.eclipse.lemminx.dom.DOMDocument.positionAt(DOMDocument.java:90)
	at org.eclipse.lemminx.utils.XMLPositionUtility.createRange(XMLPositionUtility.java:941)
	at org.eclipse.lemminx.extensions.maven.participants.completion.MavenCompletionParticipant.internalCollectRemoteGAVCompletion(MavenCompletionParticipant.java:787)
	at org.eclipse.lemminx.extensions.maven.participants.completion.MavenCompletionParticipant.onXMLContent(MavenCompletionParticipant.java:313)
```