### PR TITLE
Experiment

### DIFF
--- a/lemminx-maven/pom.xml
+++ b/lemminx-maven/pom.xml
@@ -26,7 +26,7 @@
 		<junit-jupiter.version>5.9.3</junit-jupiter.version>
 		<lemminx.version>0.26.1</lemminx.version>
 		<maven.version>3.9.2</maven.version>
-		<maven-resolver.version>1.9.12</maven-resolver.version>
+		<maven-resolver.version>1.9.13</maven-resolver.version>
 	</properties>
 
 	<dependencies>

--- a/lemminx-maven/src/main/java/org/eclipse/lemminx/extensions/maven/MavenLemminxExtension.java
+++ b/lemminx-maven/src/main/java/org/eclipse/lemminx/extensions/maven/MavenLemminxExtension.java
@@ -198,6 +198,7 @@ public class MavenLemminxExtension implements IXMLExtension {
 			this.container = newPlexusContainer();
 			mavenRequest = initMavenRequest(container, settings);
 			DefaultRepositorySystemSessionFactory repositorySessionFactory = container.lookup(DefaultRepositorySystemSessionFactory.class);
+			mavenRequest.getUserProperties().setProperty("aether.syncContext.named.factory", "noop");
 			RepositorySystemSession repositorySystemSession = repositorySessionFactory.newRepositorySession(mavenRequest);
 			MavenExecutionResult mavenResult = new DefaultMavenExecutionResult();
 			// TODO: MavenSession is deprecated. Investigate for alternative


### PR DESCRIPTION
Changes:
* Upgrade resolver to 1.9.13 (does not really matter due that below)
* Use no-op locking (so let FS does it's best, will probably explode on Windows)