### PR TITLE
Fix for "java.lang.IllegalStateException: Could not acquire lock(s)" in MavenLemminxWorkspaceReader

### DIFF
--- a/lemminx-maven/src/main/java/org/eclipse/lemminx/extensions/maven/participants/rename/MavenPropertyRenameParticipant.java
+++ b/lemminx-maven/src/main/java/org/eclipse/lemminx/extensions/maven/participants/rename/MavenPropertyRenameParticipant.java
@@ -94,7 +94,7 @@ public class MavenPropertyRenameParticipant implements IRenameParticipant {
 		cancelChecker.checkCanceled();
 		LinkedHashSet<MavenProject> projects = new LinkedHashSet<>();
 		projects.add(thisProject);
-		plugin.getProjectCache().getProjects().stream().forEach(child -> 
+		plugin.getCurrentWorkspaceProjects().stream().forEach(child -> 
 			projects.addAll(findParentsOfChildProject(thisProject, child)));
 
 		String propertyName = element.getNodeName();


### PR DESCRIPTION
Change Workspacereader  populate thread to not use `ProjectBuilder.build()` API sue to the possibility
    to be blocked on locking.
    
Also the PR https://github.com/eclipse/lemminx-maven/pull/425 is used as the source of ProjectBuildingRequest locking configuration:
```
request.getUserProperties().setProperty("aether.syncContext.named.factory", "noop");
```
Thanks to @cstamas.