### PR TITLE
Fix NPE when comparing versions in Content Assist

### DIFF
--- a/lemminx-maven/src/main/java/org/eclipse/lemminx/extensions/maven/participants/completion/MavenCompletionParticipant.java
+++ b/lemminx-maven/src/main/java/org/eclipse/lemminx/extensions/maven/participants/completion/MavenCompletionParticipant.java
@@ -356,12 +356,16 @@ public class MavenCompletionParticipant extends CompletionParticipantAdapter {
 				// Sort and move nonArtifactCollector items to the response and clear nonArtifactCollector
 				nonArtifactCollector.entrySet().stream()
 				.map(entry -> entry.getValue())
+				.filter(Objects::nonNull)
+				.filter(item -> item.getSortText() != null || item.getLabel() != null)
 				.sorted(new Comparator<CompletionItem>() {
 					// Backward order
 					@Override
 					public int compare(CompletionItem o1, CompletionItem o2) {
-						return new DefaultArtifactVersion(o2.getSortText())
-								.compareTo(new DefaultArtifactVersion(o1.getSortText()));
+						String sortText1 = o1.getSortText() != null ? o1.getSortText() : o1.getLabel();
+						String sortText2 = o2.getSortText() != null ? o2.getSortText() : o2.getLabel();
+						return new DefaultArtifactVersion(sortText2)
+								.compareTo(new DefaultArtifactVersion(sortText1));
 					}
 				})
 				.forEach(response::addCompletionItem);


### PR DESCRIPTION
```
Jul 06, 2023 10:50:27 AM org.eclipse.lemminx.services.XMLCompletions collectInsideContent
SEVERE: While performing ICompletionParticipant#onXMLContent for participant 'org.eclipse.lemminx.extensions.maven.participants.completion.MavenCompletionParticipant'.
java.lang.NullPointerException: Cannot invoke "String.toLowerCase(java.util.Locale)" because "version" is null
	at org.apache.maven.artifact.versioning.ComparableVersion.parseVersion(ComparableVersion.java:543)
	at org.apache.maven.artifact.versioning.ComparableVersion.<init>(ComparableVersion.java:534)
	at org.apache.maven.artifact.versioning.DefaultArtifactVersion.parseVersion(DefaultArtifactVersion.java:94)
	at org.apache.maven.artifact.versioning.DefaultArtifactVersion.<init>(DefaultArtifactVersion.java:44)
	at org.eclipse.lemminx.extensions.maven.participants.completion.MavenCompletionParticipant$1.compare(MavenCompletionParticipant.java:364)
	at org.eclipse.lemminx.extensions.maven.participants.completion.MavenCompletionParticipant$1.compare(MavenCompletionParticipant.java:359)
	at java.base/java.util.TimSort.countRunAndMakeAscending(TimSort.java:355)
	at java.base/java.util.TimSort.sort(TimSort.java:220)
	at java.base/java.util.Arrays.sort(Arrays.java:1307)
	at java.base/java.util.stream.SortedOps$SizedRefSortingSink.end(SortedOps.java:353)
	at java.base/java.util.stream.Sink$ChainedReference.end(Sink.java:258)
	at java.base/java.util.stream.AbstractPipeline.copyInto(AbstractPipeline.java:510)
	at java.base/java.util.stream.AbstractPipeline.wrapAndCopyInto(AbstractPipeline.java:499)
	at java.base/java.util.stream.ForEachOps$ForEachOp.evaluateSequential(ForEachOps.java:150)
	at java.base/java.util.stream.ForEachOps$ForEachOp$OfRef.evaluateSequential(ForEachOps.java:173)
	at java.base/java.util.stream.AbstractPipeline.evaluate(AbstractPipeline.java:234)
	at java.base/java.util.stream.ReferencePipeline.forEach(ReferencePipeline.java:596)
	at org.eclipse.lemminx.extensions.maven.participants.completion.MavenCompletionParticipant.onXMLContent(MavenCompletionParticipant.java:367)
	at org.eclipse.lemminx.services.XMLCompletions.collectInsideContent(XMLCompletions.java:798)
	at org.eclipse.lemminx.services.XMLCompletions.doComplete(XMLCompletions.java:260)
	at org.eclipse.lemminx.services.XMLLanguageService.doComplete(XMLLanguageService.java:171)
	at org.eclipse.lemminx.services.XMLLanguageService.doComplete(XMLLanguageService.java:166)
	at org.eclipse.lemminx.extensions.maven.participants.completion.MavenCompletionParticipantDuplicationTest.testDuplicateCompletionVersion(MavenCompletionParticipantDuplicationTest.java:83)
```