### PR TITLE
Fix NPE in 'LocalRepositorySearcher.getLocalArtifactsLastVersion'

### DIFF
--- a/lemminx-maven/src/main/java/org/eclipse/lemminx/extensions/maven/searcher/LocalRepositorySearcher.java
+++ b/lemminx-maven/src/main/java/org/eclipse/lemminx/extensions/maven/searcher/LocalRepositorySearcher.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019-2020 Red Hat Inc. and others.
+ * Copyright (c) 2019, 2023 Red Hat Inc. and others.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/
@@ -70,7 +70,7 @@ public class LocalRepositorySearcher {
 			new Thread(() -> {
 				WatchKey key;
 				try {
-					while ((key = watchService.take()) != null) {
+					while ((key = (watchService != null ? watchService.take() : null)) != null) {
 						if (watchKey.equals(key)) {
 							cache.remove(localRepository);
 							key.reset();


### PR DESCRIPTION
```
Exception in thread "Thread-61" java.lang.NullPointerException: Cannot invoke "java.nio.file.WatchService.take()" because "this.watchService" is null
	at org.eclipse.lemminx.extensions.maven.searcher.LocalRepositorySearcher.lambda$getLocalArtifactsLastVersion$1(LocalRepositorySearcher.java:73)
	at java.base/java.lang.Thread.run(Thread.java:833)
```