### PR TITLE
Fix Maven Property Refactoring Code Actions so they are compatible w…

### DIFF
--- a/lemminx-maven/src/main/java/org/eclipse/lemminx/extensions/maven/participants/codeaction/ExtractPropertyCodeAction.java
+++ b/lemminx-maven/src/main/java/org/eclipse/lemminx/extensions/maven/participants/codeaction/ExtractPropertyCodeAction.java
@@ -18,6 +18,7 @@ import static org.eclipse.lemminx.extensions.maven.MavenLemminxExtension.key;
 import java.net.URI;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
 import java.util.List;
@@ -166,17 +167,21 @@ public class ExtractPropertyCodeAction implements ICodeActionParticipant {
 					List<TextEdit> singleTextEdits = new ArrayList<>();
 					singleTextEdits.add(headerTextEdit);
 					singleTextEdits.add(new TextEdit(singleRange, "${" + propertyName + "}"));
-					codeActions.add(CodeActionFactory.replace(
+					CodeAction extractCodeAction = CodeActionFactory.replace( 
 							"Extract as new property in current module", 
-							singleTextEdits, document.getTextDocument(),  null));
+							singleTextEdits, document.getTextDocument(),  null);
+					extractCodeAction.setDiagnostics(Collections.emptyList());
+					codeActions.add(extractCodeAction);
 
 					//	Replace with existing "${already.existing.property}" property
 					exactValueProperties.stream().forEach(p -> {
 						List<TextEdit> singleReplaceTextEdits = new ArrayList<>();
 						singleReplaceTextEdits.add(new TextEdit(singleRange, "${" + p + "}"));
-						codeActions.add(CodeActionFactory.replace(
+						CodeAction replaceCodeAction = CodeActionFactory.replace( 
 								"Replace with existing \"$" + p + "}\" property", 
-								singleReplaceTextEdits, document.getTextDocument(),  null));
+								singleReplaceTextEdits, document.getTextDocument(),  null);
+						replaceCodeAction.setDiagnostics(Collections.emptyList());
+						codeActions.add(replaceCodeAction);
 					});
 					
 					//	Extract as new property in parent ggg:aaa:vvv
@@ -186,8 +191,10 @@ public class ExtractPropertyCodeAction implements ICodeActionParticipant {
 							TextDocumentEdit singleBodyEdit = createProjectTextDocumentEdit(document.getTextDocument(), 
 									Arrays.asList(new TextEdit(singleRange, "${" + propertyName + "}")));
 							
-							codeActions.add(createReplaceCodeActione("Extract as new property in  parent \"" + key(p) + "\"",
-									Arrays.asList(projectHeaderEdit, singleBodyEdit), null));
+							CodeAction extractAsNewCodeAction = createReplaceCodeActione("Extract as new property in  parent \"" + key(p) + "\"",
+									Arrays.asList(projectHeaderEdit, singleBodyEdit), null);
+							extractAsNewCodeAction.setDiagnostics(Collections.emptyList());
+							codeActions.add(extractAsNewCodeAction);
 						}
 					});
 				}
@@ -205,9 +212,11 @@ public class ExtractPropertyCodeAction implements ICodeActionParticipant {
 					multipleRanges.stream().forEach(r -> {
 						multipleTextEdits.add(new TextEdit(r, "${" + propertyName + "}"));
 					});
-					codeActions.add(CodeActionFactory.replace(
+					CodeAction multipleExtractCodeAction = CodeActionFactory.replace( 
 							"Extract all values as new property in current module", 
-							multipleTextEdits, document.getTextDocument(),  null));
+							multipleTextEdits, document.getTextDocument(),  null);
+					multipleExtractCodeAction.setDiagnostics(Collections.emptyList());
+					codeActions.add(multipleExtractCodeAction);
 
 					// Replace all values with existing "${already.existing.property}" property
 					exactValueProperties.stream().forEach(p -> {
@@ -215,9 +224,11 @@ public class ExtractPropertyCodeAction implements ICodeActionParticipant {
 						multipleRanges.stream().forEach(r -> {
 							multipleReplaceTextEdits.add(new TextEdit(r, "${" + p + "}"));
 						});
-						codeActions.add(CodeActionFactory.replace(
+						CodeAction multipleReplaceCodeAction = CodeActionFactory.replace( 
 								"Replace all values with existing \"$" + p + "}\" property", 
-								multipleReplaceTextEdits, document.getTextDocument(),  null));
+								multipleReplaceTextEdits, document.getTextDocument(),  null);
+						multipleReplaceCodeAction.setDiagnostics(Collections.emptyList());
+						codeActions.add(multipleReplaceCodeAction);
 					});
 	
 					// Extract all values as new property in parent ggg:aaa:vvv
@@ -228,9 +239,12 @@ public class ExtractPropertyCodeAction implements ICodeActionParticipant {
 							multipleBodyEdits.add(new TextEdit(r, "${" + propertyName + "}"));
 						});
 						if (projectHeaderEdit != null) {
-							codeActions.add(createReplaceCodeActione("Extract all values as new property in  parent \"" + key(p) + "\"",
+							CodeAction multipleExtractAsNewCodeAction = 
+									createReplaceCodeActione("Extract all values as new property in  parent \"" + key(p) + "\"",
 									Arrays.asList(projectHeaderEdit, 
-											createProjectTextDocumentEdit(document.getTextDocument(), multipleBodyEdits)), null));
+											createProjectTextDocumentEdit(document.getTextDocument(), multipleBodyEdits)), null);
+							multipleExtractAsNewCodeAction.setDiagnostics(Collections.emptyList());
+							codeActions.add(multipleExtractAsNewCodeAction);
 						}
 					});
 				}

--- a/lemminx-maven/src/main/java/org/eclipse/lemminx/extensions/maven/participants/codeaction/InlinePropertyCodeAction.java
+++ b/lemminx-maven/src/main/java/org/eclipse/lemminx/extensions/maven/participants/codeaction/InlinePropertyCodeAction.java
@@ -9,6 +9,8 @@
 package org.eclipse.lemminx.extensions.maven.participants.codeaction;
 
 import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -77,17 +79,21 @@ public class InlinePropertyCodeAction implements ICodeActionParticipant {
 								.filter(e -> rangeContains(e.getRange(), range.getStart()))
 								.findFirst().orElse(null);
 						if (thisEdit != null) {
-							codeActions.add(CodeActionFactory.replace( 
+							CodeAction ca = CodeActionFactory.replace( 
 									"Inline Property", thisEdit.getRange(), thisEdit.getNewText(), 
-									document.getTextDocument(),  null));
+									document.getTextDocument(),  null);
+							ca.setDiagnostics(Collections.emptyList());
+							codeActions.add(ca);
 						}
 					} 
 					
 					if (textEdits.size() > 1) {
 						// Replace the property with its value in entire document
-						codeActions.add(CodeActionFactory.replace(
+						CodeAction ca = CodeActionFactory.replace( 
 								"Inline all Properties", 
-								textEdits, document.getTextDocument(),  null));
+								textEdits, document.getTextDocument(),  null);
+						ca.setDiagnostics(Collections.emptyList());
+						codeActions.add(ca);
 					}
 				}
 			}

--- a/lemminx-maven/src/test/java/org/eclipse/lemminx/extensions/maven/participants/codeaction/MavenCodeActionPropertyRefactoringTest.java
+++ b/lemminx-maven/src/test/java/org/eclipse/lemminx/extensions/maven/participants/codeaction/MavenCodeActionPropertyRefactoringTest.java
@@ -20,6 +20,7 @@ import static org.junit.jupiter.api.Assertions.fail;
 import java.net.URI;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -70,6 +71,8 @@ public class MavenCodeActionPropertyRefactoringTest {
 		CodeAction expectedCodeAction = ca(null, 
 				teOp(xmlDocument.getDocumentURI(), positionStart.getLine(), positionStart.getCharacter(), 
 						positionEnd.getLine(), positionEnd.getCharacter(), "my-property-group-value"));
+		expectedCodeAction.setDiagnostics(Collections.emptyList()); // No diagnostic should be provided
+		
 		// Test for expected code actions returned
 		testCodeActionsFor(xmlDocument.getText(), null, new Range(positionStart, positionEnd), 
 				(String) null, xmlDocument.getDocumentURI(),  sharedSettings, xmlLanguageService, -1, 
@@ -107,6 +110,7 @@ public class MavenCodeActionPropertyRefactoringTest {
 						ranges.get(0).getStart().getLine(), ranges.get(0).getStart().getCharacter(), 
 						ranges.get(0).getEnd().getLine(), ranges.get(0).getEnd().getCharacter(), 
 						"my-property-group-value"));
+		expectedCodeAction_1.setDiagnostics(Collections.emptyList()); // No diagnostic should be provided
 		
 		// Inline for all the property uses in pom.xml 
 		List<TextEdit> textEdits = ranges.stream().map(range -> 
@@ -115,6 +119,7 @@ public class MavenCodeActionPropertyRefactoringTest {
 				"my-property-group-value")).collect(Collectors.toList()) ;
 		assertTrue(textEdits.size() == ranges.size(), "The TextEdits size should be equl to the size of ranges");
 		CodeAction expectedCodeAction_2 = ca(null,  teOp(xmlDocument.getDocumentURI(), textEdits.toArray(new TextEdit[textEdits.size()])));
+		expectedCodeAction_2.setDiagnostics(Collections.emptyList()); // No diagnostic should be provided
 
 		// Test for expected code actions returned
 		testCodeActionsFor(xmlDocument.getText(), null, ranges.get(0), 
@@ -166,7 +171,8 @@ public class MavenCodeActionPropertyRefactoringTest {
 		assertTrue(textEdits.size() == 2, "The TextEdits size should be 2");
 		CodeAction expectedCodeAction = ca(null,  
 				teOp(xmlDocument.getDocumentURI(), textEdits.toArray(new TextEdit[textEdits.size()])));
-		
+		expectedCodeAction.setDiagnostics(Collections.emptyList()); // No diagnostic should be provided
+
 		// Test for expected code actions returned
 		testCodeActionsFor(xmlDocument.getText(), null, new Range(position, position), 
 				(String) null, xmlDocument.getDocumentURI(),  sharedSettings, xmlLanguageService, -1, 
@@ -220,6 +226,7 @@ public class MavenCodeActionPropertyRefactoringTest {
 		assertTrue(singleTextEdits.size() == 2, "The TextEdits size should be 2");
 		CodeAction expectedCodeAction_1 = ca(null,  
 				teOp(xmlDocument.getDocumentURI(), singleTextEdits.toArray(new TextEdit[singleTextEdits.size()])));
+		expectedCodeAction_1.setDiagnostics(Collections.emptyList()); // No diagnostic should be provided
 		
 		// Code action for extracting all the value uses to a property 
 
@@ -231,6 +238,7 @@ public class MavenCodeActionPropertyRefactoringTest {
 			"${test-1-version}")).collect(Collectors.toList())) ;
 		assertTrue(multipleTextEdits.size() == ranges.size() + 1, "The TextEdits size should be equl to the size of ranges");
 		CodeAction expectedCodeAction_2 = ca(null,  teOp(xmlDocument.getDocumentURI(), multipleTextEdits.toArray(new TextEdit[multipleTextEdits.size()])));
+		expectedCodeAction_2.setDiagnostics(Collections.emptyList()); // No diagnostic should be provided
 
 		// Test for expected code actions returned
 		testCodeActionsFor(xmlDocument.getText(), null, ranges.get(0), 
@@ -299,6 +307,7 @@ public class MavenCodeActionPropertyRefactoringTest {
 		assertTrue(singleTextEdits.size() == 2, "The TextEdits size should be 2");
 		CodeAction expectedCodeAction_1 = ca(null,  
 				teOp(xmlDocument.getDocumentURI(), singleTextEdits.toArray(new TextEdit[singleTextEdits.size()])));
+		expectedCodeAction_1.setDiagnostics(Collections.emptyList()); // No diagnostic should be provided
 
 		// Code action for replacing a single value with an existing property
 
@@ -307,6 +316,7 @@ public class MavenCodeActionPropertyRefactoringTest {
 		assertTrue(singleReplaceTextEdits.size() == 1, "The TextEdits size should be 1");
 		CodeAction expectedCodeAction_2 = ca(null,  
 				teOp(xmlDocument.getDocumentURI(), singleReplaceTextEdits.toArray(new TextEdit[singleReplaceTextEdits.size()])));
+		expectedCodeAction_2.setDiagnostics(Collections.emptyList()); // No diagnostic should be provided
 	
 		// Code action for extracting a single value into a property in parent project
 
@@ -336,6 +346,7 @@ public class MavenCodeActionPropertyRefactoringTest {
 		CodeAction expectedCodeAction_3 = ca(null,  
 				teOp(parentXmlDocument.getDocumentURI(), headerTextEdits.toArray(new TextEdit[headerTextEdits.size()])),
 				teOp(xmlDocument.getDocumentURI(), bodyTextEdits.toArray(new TextEdit[bodyTextEdits.size()])));
+		expectedCodeAction_3.setDiagnostics(Collections.emptyList()); // No diagnostic should be provided
 
 		// Test for expected code actions returned
 		testCodeActionsFor(xmlDocument.getText(), null, ranges.get(0), 


### PR DESCRIPTION
…ith VSCode

The Maven Property Refactoring Code Actions shoul be initiated with an empty list of Diagnostic (instead of list of 'null') in order to be compatible to VSCode Quick Fixes.