### PR TITLE
[build] Create Lemminx-Maven Uber Zip

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -48,11 +48,13 @@ The LemMinX-Maven extension must be debugged remotely as it's most useful when c
 	$ mvnw.cmd verify -DskipTests -Pgenerate-vscode-jars
 	```
 
-2. Clone and build VSCode-XML extension, See: [VSCode-XML Extension Contribution Guide](https://github.com/redhat-developer/vscode-xml/blob/main/CONTRIBUTING.md#steps)
+This produces the `<LemMinX-Maven>/lemminx-maven/target/vscode-lemminx-maven-jars` directory containing all the Jars required to run LemMinX-Maven extension in VSCode XML as well as the `lemminx-maven-<version>-vscode-uber-jars.zip` Zip-archive with the contents of this directory.
 
-3. Try running the VSCode-XML extension to make sure everything is correctly installed and XML editor works (validation, content assist, hovers, etc. for XML tags and attributes)
+2. Clone and build VSCode-XML extension, See: [VSCode-XML Extension Contribution Guide](https://github.com/redhat-developer/vscode-xml/blob/main/CONTRIBUTING.md#steps).
 
-4. Copy `<LemMinX-Maven>/lemminx-maven/target/vscode-lemminx-maven-jars` directory to VSCode-XML extension project directory and make sure it's visible in `vscode-xml`project in VSCode 
+3. Try running the VSCode-XML extension to make sure everything is correctly installed and XML editor works (validation, content assist, hovers, etc. for XML tags and attributes).
+
+4. Copy `<LemMinX-Maven>/lemminx-maven/target/vscode-lemminx-maven-jars` directory to VSCode-XML extension project directory and make sure it's visible in `vscode-xml`project in VSCode .
 
 5. In VSCode modify `vscode-xml/package.json` adding the following configuration to the `contributes` section:
 

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -11,7 +11,7 @@ pipeline{
 	stages{
 		stage("Maven Build"){
 			steps {
-				sh 'mvn -B verify --file lemminx-maven/pom.xml -Dmaven.test.error.ignore=true -Dmaven.test.failure.ignore=true'
+				sh 'mvn -B verify --file lemminx-maven/pom.xml -Pgenerate-vscode-jars -Dmaven.test.error.ignore=true -Dmaven.test.failure.ignore=true'
 			}
 			post {
 				always {

--- a/lemminx-maven/pom.xml
+++ b/lemminx-maven/pom.xml
@@ -194,15 +194,15 @@
 			<plugin>
 				<artifactId>maven-assembly-plugin</artifactId>
 				<version>3.6.0</version>
-				<configuration>
-					<descriptors>
-						<descriptor>src/assembly/deps.xml</descriptor>
-					</descriptors>
-				</configuration>
 				<executions>
 					<execution>
 						<id>zip-with-dependencies</id>
 						<phase>package</phase>
+						<configuration>
+							<descriptors>
+								<descriptor>src/assembly/deps.xml</descriptor>
+							</descriptors>
+						</configuration>
 						<goals>
 							<goal>single</goal>
 						</goals>
@@ -249,7 +249,6 @@
 								<goals>
 									<goal>copy</goal>
 								</goals>
-
 							</execution>
 						</executions>
 						<configuration>
@@ -259,6 +258,24 @@
 							<overWriteSnapshots>true</overWriteSnapshots>
 							<overWriteIfNewer>true</overWriteIfNewer>
 						</configuration>
+					</plugin>
+					<plugin>
+						<artifactId>maven-assembly-plugin</artifactId>
+						<version>3.6.0</version>
+						<executions>
+							<execution>
+								<id>lemminx-maven-vscode-uber-zip</id>
+								<phase>package</phase>
+								<configuration>
+									<descriptors>
+										<descriptor>src/assembly/vscode-uber.xml</descriptor>
+									</descriptors>
+								</configuration>
+								<goals>
+									<goal>single</goal>
+								</goals>
+							</execution>
+						</executions>
 					</plugin>
 				</plugins>
 			</build>

--- a/lemminx-maven/src/assembly/vscode-uber.xml
+++ b/lemminx-maven/src/assembly/vscode-uber.xml
@@ -1,0 +1,15 @@
+<assembly xmlns="http://maven.apache.org/ASSEMBLY/2.1.0"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://maven.apache.org/ASSEMBLY/2.1.0 http://maven.apache.org/xsd/assembly-2.1.0.xsd">
+	<id>vscode-uber-jars</id>
+	<formats>
+		<format>zip</format>
+	</formats>
+	<includeBaseDirectory>false</includeBaseDirectory>
+	<fileSets>
+		<fileSet>
+			<directory>target/vscode-lemminx-maven-jars</directory>
+			<outputDirectory></outputDirectory>
+		</fileSet>
+	</fileSets>
+</assembly>


### PR DESCRIPTION
This PR also makes the build,  when executed with  `-Pgenerate-vscode-jars ` argument, to pack the contents of `vscode-lemminx-maven-jars` directory to `lemminx-maven-<version>-vscode-uber-jars.zip` and upload this archive to the releass/snapshots repositories.

Issue: #430