### PR TITLE
Fix 'MavenPluginUtils.getContainingPluginDescriptor' error processing

### DIFF
--- a/lemminx-maven/src/main/java/org/eclipse/lemminx/extensions/maven/MavenLemminxWorkspaceReader.java
+++ b/lemminx-maven/src/main/java/org/eclipse/lemminx/extensions/maven/MavenLemminxWorkspaceReader.java
@@ -159,7 +159,7 @@ public class MavenLemminxWorkspaceReader implements WorkspaceReader {
 				// XML document is invalid fo parsing (eg user is typing), it's a valid state that shouldn't log
 				// exceptions
 			} catch (IOException ex) {
-				LOGGER.log(Level.SEVERE, ex.getMessage(), ex);
+				LOGGER.log(Level.SEVERE, "Couldn't read Maven project: " + file.getAbsolutePath() + " : " + ex.getMessage(), ex);
 			}
 			return Optional.empty();
 		}

--- a/lemminx-maven/src/main/java/org/eclipse/lemminx/extensions/maven/participants/diagnostics/PluginValidator.java
+++ b/lemminx-maven/src/main/java/org/eclipse/lemminx/extensions/maven/participants/diagnostics/PluginValidator.java
@@ -42,7 +42,7 @@ class PluginValidator {
 
 	public Optional<List<Diagnostic>> validatePluginResolution(DiagnosticRequest diagnosticRequest) {
 		try {
-			MavenPluginUtils.getContainingPluginDescriptor(diagnosticRequest.getNode(), plugin);
+			MavenPluginUtils.getContainingPluginDescriptor(diagnosticRequest.getNode(), plugin, true);
 		} catch (PluginResolutionException | PluginDescriptorParsingException | InvalidPluginDescriptorException e) {
 			LOGGER.log(Level.WARNING, "Could not resolve plugin description", e);
 


### PR DESCRIPTION
A different kind of exceptions may occur when tying to get a plugin descriptor and, if not caught and processed, may break the normal functionality

```
Jul 20, 2023 5:23:08 PM org.eclipse.lemminx.extensions.maven.participants.diagnostics.PluginValidator validatePluginResolution
WARNING: Could not resolve plugin description
org.apache.maven.plugin.PluginDescriptorParsingException: Failed to parse plugin descriptor for org.eclipse.tycho:tycho-repository-plugin:5.0.0-SNAPSHOT (/home/jeremy/projects/eclipse/source/tycho/tycho-repository-plugin/pom.xml): zip END header not found
	at org.apache.maven.plugin.internal.DefaultMavenPluginManager.extractPluginDescriptor(DefaultMavenPluginManager.java:228)
	at org.apache.maven.plugin.internal.DefaultMavenPluginManager.lambda$getPluginDescriptor$0(DefaultMavenPluginManager.java:182)
	at org.apache.maven.plugin.DefaultPluginDescriptorCache.lambda$get$0(DefaultPluginDescriptorCache.java:72)
	at java.base/java.util.concurrent.ConcurrentHashMap.computeIfAbsent(ConcurrentHashMap.java:1708)
	at org.apache.maven.plugin.DefaultPluginDescriptorCache.get(DefaultPluginDescriptorCache.java:70)
	at org.apache.maven.plugin.internal.DefaultMavenPluginManager.getPluginDescriptor(DefaultMavenPluginManager.java:176)
	at org.eclipse.lemminx.extensions.maven.utils.MavenPluginUtils.getContainingPluginDescriptor(MavenPluginUtils.java:192)
	at org.eclipse.lemminx.extensions.maven.participants.diagnostics.PluginValidator.validatePluginResolution(PluginValidator.java:45)
	at org.eclipse.lemminx.extensions.maven.participants.diagnostics.PluginValidator.validateGoal(PluginValidator.java:107)
	at org.eclipse.lemminx.extensions.maven.participants.diagnostics.MavenDiagnosticParticipant.lambda$doDiagnostics$3(MavenDiagnosticParticipant.java:84)
	at java.base/java.util.stream.ReferencePipeline$3$1.accept(ReferencePipeline.java:197)
	at java.base/java.util.stream.ReferencePipeline$2$1.accept(ReferencePipeline.java:179)
	at java.base/java.util.HashMap$EntrySpliterator.forEachRemaining(HashMap.java:1850)
	at java.base/java.util.stream.AbstractPipeline.copyInto(AbstractPipeline.java:509)
	at java.base/java.util.stream.AbstractPipeline.wrapAndCopyInto(AbstractPipeline.java:499)
	at java.base/java.util.stream.ForEachOps$ForEachOp.evaluateSequential(ForEachOps.java:150)
	at java.base/java.util.stream.ForEachOps$ForEachOp$OfRef.evaluateSequential(ForEachOps.java:173)
	at java.base/java.util.stream.AbstractPipeline.evaluate(AbstractPipeline.java:234)
	at java.base/java.util.stream.ReferencePipeline.forEach(ReferencePipeline.java:596)
	at org.eclipse.lemminx.extensions.maven.participants.diagnostics.MavenDiagnosticParticipant.doDiagnostics(MavenDiagnosticParticipant.java:85)
	at org.eclipse.lemminx.services.XMLDiagnostics.doExtensionsDiagnostics(XMLDiagnostics.java:67)
	at org.eclipse.lemminx.services.XMLDiagnostics.doDiagnostics(XMLDiagnostics.java:49)
	at org.eclipse.lemminx.services.XMLLanguageService.doDiagnostics(XMLLanguageService.java:190)
	at org.eclipse.lemminx.services.XMLLanguageService.publishDiagnostics(XMLLanguageService.java:204)
	at org.eclipse.lemminx.XMLTextDocumentService.validate(XMLTextDocumentService.java:716)
	at org.eclipse.lemminx.XMLTextDocumentService.lambda$new$2(XMLTextDocumentService.java:207)
	at org.eclipse.lemminx.commons.ModelValidatorDelayer.lambda$validateWithDelay$0(ModelValidatorDelayer.java:69)
	at java.base/java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:539)
	at java.base/java.util.concurrent.FutureTask.run(FutureTask.java:264)
	at java.base/java.util.concurrent.ScheduledThreadPoolExecutor$ScheduledFutureTask.run(ScheduledThreadPoolExecutor.java:304)
	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1136)
	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:635)
	at java.base/java.lang.Thread.run(Thread.java:833)
Caused by: java.util.zip.ZipException: zip END header not found
	at java.base/java.util.zip.ZipFile$Source.findEND(ZipFile.java:1469)
	at java.base/java.util.zip.ZipFile$Source.initCEN(ZipFile.java:1477)
	at java.base/java.util.zip.ZipFile$Source.<init>(ZipFile.java:1315)
	at java.base/java.util.zip.ZipFile$Source.get(ZipFile.java:1277)
	at java.base/java.util.zip.ZipFile$CleanableResource.<init>(ZipFile.java:709)
	at java.base/java.util.zip.ZipFile.<init>(ZipFile.java:243)
	at java.base/java.util.zip.ZipFile.<init>(ZipFile.java:172)
	at java.base/java.util.jar.JarFile.<init>(JarFile.java:347)
	at java.base/java.util.jar.JarFile.<init>(JarFile.java:318)
	at java.base/java.util.jar.JarFile.<init>(JarFile.java:298)
	at org.apache.maven.plugin.internal.DefaultMavenPluginManager.extractPluginDescriptor(DefaultMavenPluginManager.java:205)
	... 32 more
```