### PR TITLE
Fix CME in 'MavenLemminxWorkspaceReader.findArtifact'

### DIFF
--- a/lemminx-maven/src/main/java/org/eclipse/lemminx/extensions/maven/MavenLemminxWorkspaceReader.java
+++ b/lemminx-maven/src/main/java/org/eclipse/lemminx/extensions/maven/MavenLemminxWorkspaceReader.java
@@ -222,7 +222,8 @@ public class MavenLemminxWorkspaceReader implements WorkspaceReader {
 	@Override
 	public File findArtifact(Artifact artifact) {
 		String projectKey = ArtifactUtils.key(artifact.getGroupId(), artifact.getArtifactId(), artifact.getVersion());
-		return plugin.getProjectCache().getProjects().stream()
+		List<MavenProject> projectsCopy = plugin.getProjectCache().getProjects().stream().toList();
+		return projectsCopy.stream()
 				.filter(p -> p.getArtifact() != null && projectKey.equals(ArtifactUtils.key(p.getArtifact())))
 				.map(project -> {
 					File file = find(project, artifact);


### PR DESCRIPTION
```
MavenProjectCache parseAndCache()
Message: null
java.util.ConcurrentModificationException
	at java.base/java.util.HashMap$ValueSpliterator.tryAdvance(HashMap.java:1802)
	at java.base/java.util.stream.ReferencePipeline.forEachWithCancel(ReferencePipeline.java:129)
	at java.base/java.util.stream.AbstractPipeline.copyIntoWithCancel(AbstractPipeline.java:527)
	at java.base/java.util.stream.AbstractPipeline.copyInto(AbstractPipeline.java:513)
	at java.base/java.util.stream.AbstractPipeline.wrapAndCopyInto(AbstractPipeline.java:499)
	at java.base/java.util.stream.FindOps$FindOp.evaluateSequential(FindOps.java:150)
	at java.base/java.util.stream.AbstractPipeline.evaluate(AbstractPipeline.java:234)
	at java.base/java.util.stream.ReferencePipeline.findAny(ReferencePipeline.java:652)
	at org.eclipse.lemminx.extensions.maven.MavenLemminxWorkspaceReader.findArtifact(MavenLemminxWorkspaceReader.java:234)
	at org.eclipse.aether.internal.impl.DefaultArtifactResolver.resolve(DefaultArtifactResolver.java:343)
	at org.eclipse.aether.internal.impl.DefaultArtifactResolver.resolveArtifacts(DefaultArtifactResolver.java:259)
	at org.eclipse.aether.internal.impl.DefaultRepositorySystem.resolveDependencies(DefaultRepositorySystem.java:352)
	at org.apache.maven.project.DefaultProjectDependenciesResolver.resolve(DefaultProjectDependenciesResolver.java:182)
	at org.apache.maven.project.DefaultProjectBuilder.resolveDependencies(DefaultProjectBuilder.java:224)
	at org.apache.maven.project.DefaultProjectBuilder.build(DefaultProjectBuilder.java:202)
	at org.apache.maven.project.DefaultProjectBuilder.build(DefaultProjectBuilder.java:139)
	at org.eclipse.lemminx.extensions.maven.MavenProjectCache.parseAndCache(MavenProjectCache.java:164)
	at org.eclipse.lemminx.extensions.maven.MavenProjectCache.parseAndCache(MavenProjectCache.java:245)
	at org.eclipse.lemminx.extensions.maven.MavenProjectCache.check(MavenProjectCache.java:124)
	at org.eclipse.lemminx.extensions.maven.MavenProjectCache.getProblemsFor(MavenProjectCache.java:117)
	at org.eclipse.lemminx.extensions.maven.participants.diagnostics.MavenDiagnosticParticipant.doDiagnostics(MavenDiagnosticParticipant.java:56)
	at org.eclipse.lemminx.services.XMLDiagnostics.doExtensionsDiagnostics(XMLDiagnostics.java:67)
	at org.eclipse.lemminx.services.XMLDiagnostics.doDiagnostics(XMLDiagnostics.java:49)
	at org.eclipse.lemminx.services.XMLLanguageService.doDiagnostics(XMLLanguageService.java:190)
	at org.eclipse.lemminx.services.XMLLanguageService.publishDiagnostics(XMLLanguageService.java:204)
	at org.eclipse.lemminx.XMLTextDocumentService.validate(XMLTextDocumentService.java:716)
	at org.eclipse.lemminx.XMLTextDocumentService.lambda$validate$35(XMLTextDocumentService.java:691)
	at java.base/java.util.concurrent.CompletableFuture$AsyncRun.run(CompletableFuture.java:1804)
	at java.base/java.util.concurrent.CompletableFuture$AsyncRun.exec(CompletableFuture.java:1796)
	at java.base/java.util.concurrent.ForkJoinTask.doExec(ForkJoinTask.java:373)
	at java.base/java.util.concurrent.ForkJoinPool$WorkQueue.topLevelExec(ForkJoinPool.java:1182)
	at java.base/java.util.concurrent.ForkJoinPool.scan(ForkJoinPool.java:1655)
	at java.base/java.util.concurrent.ForkJoinPool.runWorker(ForkJoinPool.java:1622)
	at java.base/java.util.concurrent.ForkJoinWorkerThread.run(ForkJoinWorkerThread.java:165)
```