### PR TITLE
Fix NPE in `LocalRepositorySearcher.findLocalFile`

### DIFF
--- a/lemminx-maven/src/main/java/org/eclipse/lemminx/extensions/maven/participants/hover/MavenHoverParticipant.java
+++ b/lemminx-maven/src/main/java/org/eclipse/lemminx/extensions/maven/participants/hover/MavenHoverParticipant.java
@@ -102,17 +102,21 @@ public class MavenHoverParticipant extends HoverParticipantAdapter {
 			return null;
 		}
 		try {
-			DOMNode tag = request.getNode();
-			DOMElement parent = tag.getParentElement();
-	
-			boolean isParentDeclaration = ParticipantUtils.isParentDeclaration(parent);
 	
 			Map.Entry<Range, String> mavenProperty = ParticipantUtils.getMavenPropertyInRequest(request);
 			if (mavenProperty != null) {
 				return collectProperty(request, mavenProperty, cancelChecker);
 			}
 			
+			DOMNode tag = request.getNode();
+			DOMElement parent = tag.getParentElement();
+			if (ParticipantUtils.isProject(parent)) {
+				// Do not show hover for the project itself
+				return null;
+			}
+		
 			cancelChecker.checkCanceled();
+			boolean isParentDeclaration = ParticipantUtils.isParentDeclaration(parent);
 			MavenProject p = plugin.getProjectCache().getLastSuccessfulMavenProject(request.getXMLDocument());
 			Dependency artifactToSearch = ParticipantUtils.getArtifactToSearch(p, tag);
 	

--- a/lemminx-maven/src/main/java/org/eclipse/lemminx/extensions/maven/searcher/LocalRepositorySearcher.java
+++ b/lemminx-maven/src/main/java/org/eclipse/lemminx/extensions/maven/searcher/LocalRepositorySearcher.java
@@ -8,6 +8,8 @@
  *******************************************************************************/
 package org.eclipse.lemminx.extensions.maven.searcher;
 
+import static org.eclipse.lemminx.extensions.maven.utils.ParticipantUtils.isWellDefinedDependency;
+
 import java.io.File;
 import java.io.IOException;
 import java.nio.file.ClosedWatchServiceException;
@@ -127,11 +129,15 @@ public class LocalRepositorySearcher {
 		return groupIdArtifactIdToVersion.values();
 	}
 
-
 	// TODO consider using directly ArtifactRepository for those 2 methods
 	public File findLocalFile(Dependency dependency) {
-		return new File(localRepository, dependency.getGroupId().replace('.', File.separatorChar) + File.separatorChar + dependency.getArtifactId() + File.separatorChar + dependency.getVersion() + File.separatorChar + dependency.getArtifactId() + '-' + dependency.getVersion() + ".pom");
+		return isWellDefinedDependency(dependency)
+				? new File(localRepository, dependency.getGroupId().replace('.', File.separatorChar)
+						+ File.separatorChar + dependency.getArtifactId() + File.separatorChar + dependency.getVersion()
+						+ File.separatorChar + dependency.getArtifactId() + '-' + dependency.getVersion() + ".pom")
+				: null;
 	}
+	
 	public File findLocalFile(Artifact gav) {
 		return new File(localRepository, gav.getGroupId().replace('.', File.separatorChar) + File.separatorChar + gav.getArtifactId() + File.separatorChar + gav.getVersion() + File.separatorChar + gav.getArtifactId() + '-' + gav.getVersion() + ".pom");
 	}

--- a/lemminx-maven/src/main/java/org/eclipse/lemminx/extensions/maven/utils/ParticipantUtils.java
+++ b/lemminx-maven/src/main/java/org/eclipse/lemminx/extensions/maven/utils/ParticipantUtils.java
@@ -20,6 +20,7 @@ import static org.eclipse.lemminx.extensions.maven.DOMConstants.GROUP_ID_ELT;
 import static org.eclipse.lemminx.extensions.maven.DOMConstants.MODULE_ELT;
 import static org.eclipse.lemminx.extensions.maven.DOMConstants.PARENT_ELT;
 import static org.eclipse.lemminx.extensions.maven.DOMConstants.PLUGIN_ELT;
+import static org.eclipse.lemminx.extensions.maven.DOMConstants.PROJECT_ELT;
 import static org.eclipse.lemminx.extensions.maven.DOMConstants.RELATIVE_PATH_ELT;
 import static org.eclipse.lemminx.extensions.maven.DOMConstants.VERSION_ELT;
 
@@ -141,6 +142,19 @@ public class ParticipantUtils {
 							.findFirst().orElse(dependency);
 				}
 			}
+		} else if (isProject(element)) {
+			DOMNode projectNode = DOMUtils.findClosestParentNode(element, PROJECT_ELT);
+			if (projectNode != null) {
+				Optional<DOMElement> parent = DOMUtils.findChildElement(projectNode, PARENT_ELT);
+				if (parent.isPresent()) {
+					if (dependency.getGroupId() == null) {
+						dependency.setGroupId(DOMUtils.findChildElementText(parent.get(), GROUP_ID_ELT).orElse(null));
+					}
+					if (dependency.getVersion() == null) {
+						dependency.setVersion(DOMUtils.findChildElementText(parent.get(), VERSION_ELT).orElse(null));
+					}
+				}
+			}
 		}
 		return dependency;
 	}
@@ -222,6 +236,11 @@ public class ParticipantUtils {
 	public static boolean isPlugin(DOMElement element) {
 		return  PLUGIN_ELT.equals(element.getLocalName()) || 
 					(element.getParentElement() != null && PLUGIN_ELT.equals(element.getParentElement().getLocalName()));
+	}
+
+	public static boolean isProject(DOMElement element) {
+		return  PROJECT_ELT.equals(element.getLocalName()) || 
+					(element.getParentElement() != null && PROJECT_ELT.equals(element.getParentElement().getLocalName()));
 	}
 	
 	public static boolean isParentDeclaration(DOMElement element) {


### PR DESCRIPTION
```
[Error - 4:46:44 AM] Jul 22, 2023 04:46:44 org.eclipse.lemminx.extensions.maven.participants.hover.MavenHoverParticipant collectArtifactDescription()
Message: java.lang.NullPointerException: Cannot invoke "String.replace(char, char)" because the return value of "org.apache.maven.model.Dependency.getGroupId()" is null
java.lang.NullPointerException: Cannot invoke "String.replace(char, char)" because the return value of "org.apache.maven.model.Dependency.getGroupId()" is null
	at org.eclipse.lemminx.extensions.maven.searcher.LocalRepositorySearcher.findLocalFile(LocalRepositorySearcher.java:133)
	at org.eclipse.lemminx.extensions.maven.participants.hover.MavenHoverParticipant.collectArtifactDescription(MavenHoverParticipant.java:394)
	at org.eclipse.lemminx.extensions.maven.participants.hover.MavenHoverParticipant.onText(MavenHoverParticipant.java:145)
	at org.eclipse.lemminx.services.XMLHover.getTextHover(XMLHover.java:214)
	at org.eclipse.lemminx.services.XMLHover.doHover(XMLHover.java:99)
	at org.eclipse.lemminx.services.XMLLanguageService.doHover(XMLLanguageService.java:185)
	at org.eclipse.lemminx.XMLTextDocumentService.lambda$hover$5(XMLTextDocumentService.java:281)
	at org.eclipse.lemminx.commons.ModelTextDocuments.lambda$computeModelAsync$0(ModelTextDocuments.java:118)
	at java.base/java.util.concurrent.CompletableFuture$UniApply.tryFire(CompletableFuture.java:646)
	at java.base/java.util.concurrent.CompletableFuture$Completion.exec(CompletableFuture.java:483)
	at java.base/java.util.concurrent.ForkJoinTask.doExec(ForkJoinTask.java:373)
	at java.base/java.util.concurrent.ForkJoinPool$WorkQueue.topLevelExec(ForkJoinPool.java:1182)
	at java.base/java.util.concurrent.ForkJoinPool.scan(ForkJoinPool.java:1655)
	at java.base/java.util.concurrent.ForkJoinPool.runWorker(ForkJoinPool.java:1622)
	at java.base/java.util.concurrent.ForkJoinWorkerThread.run(ForkJoinWorkerThread.java:165)
```