### PR TITLE
Fix SIOOBE in 'ParticipantUtils.getMavenProperty'

### DIFF
--- a/lemminx-maven/src/main/java/org/eclipse/lemminx/extensions/maven/utils/ParticipantUtils.java
+++ b/lemminx-maven/src/main/java/org/eclipse/lemminx/extensions/maven/utils/ParticipantUtils.java
@@ -323,22 +323,30 @@ public class ParticipantUtils {
 			return null;
 		}
 
-		int hoverLocation = offset;
 		int propertyOffset = tag.getStart();
-		int beforeHover = hoverLocation - propertyOffset;
-
-		String beforeHoverText = tagText.substring(0, beforeHover);
-		String afterHoverText = tagText.substring(beforeHover);
-
-		int indexOpen = beforeHoverText.lastIndexOf("${");
-		int indexCloseBefore = beforeHoverText.lastIndexOf('}');
-		int indexCloseAfter = afterHoverText.indexOf('}');
-		if (indexOpen > indexCloseBefore) {
-			String propertyText = tagText.substring(indexOpen + 2, indexCloseAfter + beforeHover);
-			int textStart = tag.getStart();
-			Range propertyRange = XMLPositionUtility.createRange(textStart + indexOpen + 2,
-					textStart + beforeHover + indexCloseAfter, tag.getOwnerDocument());
-			return Map.entry(propertyRange, propertyText);
+		int beforeHover = offset - propertyOffset;
+		try {
+			String beforeHoverText = tagText.substring(0, beforeHover);
+			String afterHoverText = tagText.substring(beforeHover);
+	
+			int indexOpen = beforeHoverText.lastIndexOf("${");
+			int indexCloseBefore = beforeHoverText.lastIndexOf('}');
+			if (indexOpen < indexCloseBefore) {
+				return null; // outside of the maven property use 
+			}
+			int indexCloseAfter = afterHoverText.indexOf('}');
+			if (indexCloseAfter == -1) {
+				return null; //incomplete maven property use
+			}
+			if (indexOpen > indexCloseBefore) {
+				String propertyText = tagText.substring(indexOpen + 2, indexCloseAfter + beforeHover);
+				int textStart = tag.getStart();
+				Range propertyRange = XMLPositionUtility.createRange(textStart + indexOpen + 2,
+						textStart + beforeHover + indexCloseAfter, tag.getOwnerDocument());
+				return Map.entry(propertyRange, propertyText);
+			}
+		} catch (Exception e) {
+			LOGGER.log(Level.SEVERE, e.toString(), e);
 		}
 		return null;
 	}


### PR DESCRIPTION
```
    Jul 25, 2023 3:03:17 PM org.eclipse.lemminx.extensions.maven.participants.codeaction.InlinePropertyCodeAction doCodeActionUnconditional
    SEVERE: begin 2, end 1, length 2
    java.lang.StringIndexOutOfBoundsException: begin 2, end 1, length 2
            at java.base/java.lang.String.checkBoundsBeginEnd(String.java:4602)
            at java.base/java.lang.String.substring(String.java:2705)
            at org.eclipse.lemminx.extensions.maven.utils.ParticipantUtils.getMavenProperty(ParticipantUtils.java:295)
            at org.eclipse.lemminx.extensions.maven.participants.codeaction.InlinePropertyCodeAction.doCodeActionUnconditional(InlinePropertyCodeAction.java:55)
            at org.eclipse.lemminx.services.XMLCodeActions.doCodeActions(XMLCodeActions.java:81)
            at org.eclipse.lemminx.services.XMLLanguageService.doCodeActions(XMLLanguageService.java:284)
            at org.eclipse.lemminx.XMLTextDocumentService.lambda$codeAction$24(XMLTextDocumentService.java:502)
            at org.eclipse.lemminx.commons.ModelTextDocuments.lambda$computeModelAsync$0(ModelTextDocuments.java:118)
            at java.base/java.util.concurrent.CompletableFuture$UniApply.tryFire(CompletableFuture.java:646)
            at java.base/java.util.concurrent.CompletableFuture$Completion.exec(CompletableFuture.java:483)
            at java.base/java.util.concurrent.ForkJoinTask.doExec(ForkJoinTask.java:373)
            at java.base/java.util.concurrent.ForkJoinPool$WorkQueue.topLevelExec(ForkJoinPool.java:1182)
            at java.base/java.util.concurrent.ForkJoinPool.scan(ForkJoinPool.java:1655)
            at java.base/java.util.concurrent.ForkJoinPool.runWorker(ForkJoinPool.java:1622)
            at java.base/java.util.concurrent.ForkJoinWorkerThread.run(ForkJoinWorkerThread.java:165)
    
    Jul 25, 2023 3:03:17 PM org.eclipse.lemminx.extensions.maven.participants.codeaction.ExtractPropertyCodeAction doCodeActionUnconditional
    SEVERE: begin 2, end 1, length 2
    java.lang.StringIndexOutOfBoundsException: begin 2, end 1, length 2
            at java.base/java.lang.String.checkBoundsBeginEnd(String.java:4602)
            at java.base/java.lang.String.substring(String.java:2705)
            at org.eclipse.lemminx.extensions.maven.utils.ParticipantUtils.getMavenProperty(ParticipantUtils.java:295)
            at org.eclipse.lemminx.extensions.maven.participants.codeaction.ExtractPropertyCodeAction.doCodeActionUnconditional(ExtractPropertyCodeAction.java:113)
            at org.eclipse.lemminx.services.XMLCodeActions.doCodeActions(XMLCodeActions.java:81)
            at org.eclipse.lemminx.services.XMLLanguageService.doCodeActions(XMLLanguageService.java:284)
            at org.eclipse.lemminx.XMLTextDocumentService.lambda$codeAction$24(XMLTextDocumentService.java:502)
            at org.eclipse.lemminx.commons.ModelTextDocuments.lambda$computeModelAsync$0(ModelTextDocuments.java:118)
            at java.base/java.util.concurrent.CompletableFuture$UniApply.tryFire(CompletableFuture.java:646)
            at java.base/java.util.concurrent.CompletableFuture$Completion.exec(CompletableFuture.java:483)
            at java.base/java.util.concurrent.ForkJoinTask.doExec(ForkJoinTask.java:373)
            at java.base/java.util.concurrent.ForkJoinPool$WorkQueue.topLevelExec(ForkJoinPool.java:1182)
            at java.base/java.util.concurrent.ForkJoinPool.scan(ForkJoinPool.java:1655)
            at java.base/java.util.concurrent.ForkJoinPool.runWorker(ForkJoinPool.java:1622)
            at java.base/java.util.concurrent.ForkJoinWorkerThread.run(ForkJoinWorkerThread.java:165)
```