### PR TITLE
Fix SIOOBE Exception in 'ParticipantUtils getMavenProperty' part 2

### DIFF
--- a/lemminx-maven/src/main/java/org/eclipse/lemminx/extensions/maven/utils/ParticipantUtils.java
+++ b/lemminx-maven/src/main/java/org/eclipse/lemminx/extensions/maven/utils/ParticipantUtils.java
@@ -325,6 +325,10 @@ public class ParticipantUtils {
 
 		int propertyOffset = tag.getStart();
 		int beforeHover = offset - propertyOffset;
+		if (beforeHover > tagText.length()) {
+			return null;
+		}
+		
 		try {
 			String beforeHoverText = tagText.substring(0, beforeHover);
 			String afterHoverText = tagText.substring(beforeHover);


### PR DESCRIPTION
```
Jul. 27, 2023 3:45:16 P.M. org.eclipse.lemminx.extensions.maven.utils.ParticipantUtils getMavenProperty
SEVERE: java.lang.StringIndexOutOfBoundsException: begin 0, end 29, length 16
java.lang.StringIndexOutOfBoundsException: begin 0, end 29, length 16
	at java.base/java.lang.String.checkBoundsBeginEnd(String.java:4602)
	at java.base/java.lang.String.substring(String.java:2705)
	at org.eclipse.lemminx.extensions.maven.utils.ParticipantUtils.getMavenProperty(ParticipantUtils.java:329)
	at org.eclipse.lemminx.extensions.maven.utils.ParticipantUtils.getMavenPropertyInRequest(ParticipantUtils.java:316)
	at org.eclipse.lemminx.extensions.maven.participants.definition.MavenDefinitionParticipant.findMavenPropertyLocation(MavenDefinitionParticipant.java:186)
	at org.eclipse.lemminx.extensions.maven.participants.definition.MavenDefinitionParticipant.findDefinition(MavenDefinitionParticipant.java:64)
	at org.eclipse.lemminx.services.XMLDefinition.findDefinition(XMLDefinition.java:62)
	at org.eclipse.lemminx.services.XMLLanguageService.findDefinition(XMLLanguageService.java:264)
	at org.eclipse.lemminx.XMLTextDocumentService.lambda$definition$18(XMLTextDocumentService.java:443)
	at org.eclipse.lemminx.commons.ModelTextDocuments.lambda$computeModelAsync$0(ModelTextDocuments.java:118)
	at java.base/java.util.concurrent.CompletableFuture$UniApply.tryFire(CompletableFuture.java:646)
	at java.base/java.util.concurrent.CompletableFuture$Completion.exec(CompletableFuture.java:483)
	at java.base/java.util.concurrent.ForkJoinTask.doExec(ForkJoinTask.java:373)
	at java.base/java.util.concurrent.ForkJoinPool$WorkQueue.topLevelExec(ForkJoinPool.java:1182)
	at java.base/java.util.concurrent.ForkJoinPool.scan(ForkJoinPool.java:1655)
	at java.base/java.util.concurrent.ForkJoinPool.runWorker(ForkJoinPool.java:1622)
	at java.base/java.util.concurrent.ForkJoinWorkerThread.run(ForkJoinWorkerThread.java:165)
```