### PR TITLE
Dependency completion performance

### DIFF
--- a/lemminx-maven/src/main/java/org/eclipse/lemminx/extensions/maven/MavenLemminxExtension.java
+++ b/lemminx-maven/src/main/java/org/eclipse/lemminx/extensions/maven/MavenLemminxExtension.java
@@ -112,7 +112,7 @@ import org.eclipse.lsp4j.WorkspaceFolder;
 public class MavenLemminxExtension implements IXMLExtension {
 	
 	// Used for tests
-	public static boolean initializeMavenOnBackground = true;
+	private static boolean unitTestMode = false;
 	
 	private static final Logger LOGGER = Logger.getLogger(MavenLemminxExtension.class.getName());
 	private static final String MAVEN_XMLLS_EXTENSION_REALM_ID = MavenLemminxExtension.class.getName();
@@ -233,7 +233,7 @@ public class MavenLemminxExtension implements IXMLExtension {
 				}
 			});
 		}
-		if (!initializeMavenOnBackground) {
+		if (isUnitTestMode()) {
 			// This code is for tests
 			try {
 				mavenInitializer.get();
@@ -700,5 +700,27 @@ public class MavenLemminxExtension implements IXMLExtension {
 			codeActionParticipants.stream().forEach(registry::unregisterCodeActionParticipant);
 			codeActionParticipants.clear();
 		}
+	}
+	
+	/**
+	 * Returns true if the lemminx maven is run in JUnit test context and false
+	 * otherwise.
+	 * 
+	 * @return true if the lemminx maven is run in JUnit test context and false
+	 *         otherwise
+	 */
+	public static boolean isUnitTestMode() {
+		return MavenLemminxExtension.unitTestMode;
+	}
+
+	/**
+	 * Set true if the lemminx maven is run in JUnit test context and false
+	 * otherwise
+	 * 
+	 * @param unitTestMode true if the lemminx maven is run in JUnit test context
+	 *                     and false otherwise
+	 */
+	public static void setUnitTestMode(boolean unitTestMode) {
+		MavenLemminxExtension.unitTestMode = unitTestMode;
 	}
 }

--- a/lemminx-maven/src/main/java/org/eclipse/lemminx/extensions/maven/MavenModelOutOfDatedException.java
+++ b/lemminx-maven/src/main/java/org/eclipse/lemminx/extensions/maven/MavenModelOutOfDatedException.java
@@ -8,18 +8,15 @@
  *******************************************************************************/
 package org.eclipse.lemminx.extensions.maven;
 
-import org.eclipse.lemminx.services.XMLLanguageService;
+import java.util.concurrent.CancellationException;
 
 /**
- * Extends {@link XMLLanguageService} to do the Maven initialization synchronously.
+ * Exception thrown when Maven model which is parsing is out of dated.
  * 
  * @author Angelo ZERR
  *
  */
-public class MavenLanguageService extends XMLLanguageService{
-	
-	public MavenLanguageService() {
-		MavenLemminxExtension.setUnitTestMode(true);
-	}
+
+public class MavenModelOutOfDatedException extends CancellationException {
 
 }

--- a/lemminx-maven/src/main/java/org/eclipse/lemminx/extensions/maven/participants/completion/MavenCompletionParticipant.java
+++ b/lemminx-maven/src/main/java/org/eclipse/lemminx/extensions/maven/participants/completion/MavenCompletionParticipant.java
@@ -104,6 +104,7 @@ import org.eclipse.lemminx.extensions.maven.DOMConstants;
 import org.eclipse.lemminx.extensions.maven.DependencyScope;
 import org.eclipse.lemminx.extensions.maven.MavenInitializationException;
 import org.eclipse.lemminx.extensions.maven.MavenLemminxExtension;
+import org.eclipse.lemminx.extensions.maven.MavenModelOutOfDatedException;
 import org.eclipse.lemminx.extensions.maven.MojoParameter;
 import org.eclipse.lemminx.extensions.maven.Phase;
 import org.eclipse.lemminx.extensions.maven.participants.ArtifactWithDescription;
@@ -189,8 +190,10 @@ public class MavenCompletionParticipant extends CompletionParticipantAdapter {
 			if (DOMUtils.isADescendantOf(tag, CONFIGURATION_ELT)) {
 				collectPluginConfiguration(request).forEach(response::addCompletionItem);
 			}
-		} catch(MavenInitializationException e) {
-			// Maven is initializing, catch the error to avoid breaking XML completion from LemMinX
+		} catch (MavenInitializationException | MavenModelOutOfDatedException e) {
+			// - Maven is initializing
+			// - or parse of maven model with DOM document is out of dated
+			// -> catch the error to avoid breaking XML completion from LemMinX
 		}
 	}
 
@@ -488,8 +491,10 @@ public class MavenCompletionParticipant extends CompletionParticipantAdapter {
 			if (request.getNode().isText()) {
 				completeProperties(request).forEach(response::addCompletionAttribute);
 			}
-		} catch(MavenInitializationException e) {
-			// Maven is initializing, catch the error to avoid breaking XML completion from LemMinX
+		} catch (MavenInitializationException | MavenModelOutOfDatedException e) {
+			// - Maven is initializing
+			// - or parse of maven model with DOM document is out of dated
+			// -> catch the error to avoid breaking XML completion from LemMinX
 		}
 	}
 	

--- a/lemminx-maven/src/main/java/org/eclipse/lemminx/extensions/maven/participants/definition/MavenDefinitionParticipant.java
+++ b/lemminx-maven/src/main/java/org/eclipse/lemminx/extensions/maven/participants/definition/MavenDefinitionParticipant.java
@@ -33,6 +33,7 @@ import org.eclipse.lemminx.dom.DOMElement;
 import org.eclipse.lemminx.dom.DOMNode;
 import org.eclipse.lemminx.extensions.maven.MavenInitializationException;
 import org.eclipse.lemminx.extensions.maven.MavenLemminxExtension;
+import org.eclipse.lemminx.extensions.maven.MavenModelOutOfDatedException;
 import org.eclipse.lemminx.extensions.maven.utils.DOMUtils;
 import org.eclipse.lemminx.extensions.maven.utils.ParticipantUtils;
 import org.eclipse.lemminx.services.extensions.IDefinitionParticipant;
@@ -177,8 +178,10 @@ public class MavenDefinitionParticipant implements IDefinitionParticipant {
 					return;
 				}
 			}
-		} catch(MavenInitializationException e) {
-			// Maven is initializing, catch the error to avoid breaking XML definition from LemMinX
+		} catch (MavenInitializationException | MavenModelOutOfDatedException e) {
+			// - Maven is initializing
+			// - or parse of maven model with DOM document is out of dated
+			// -> catch the error to avoid breaking XML definition from LemMinX
 		}
 	}
 	

--- a/lemminx-maven/src/main/java/org/eclipse/lemminx/extensions/maven/participants/diagnostics/MavenDiagnosticParticipant.java
+++ b/lemminx-maven/src/main/java/org/eclipse/lemminx/extensions/maven/participants/diagnostics/MavenDiagnosticParticipant.java
@@ -33,6 +33,7 @@ import org.eclipse.lemminx.dom.DOMNode;
 import org.eclipse.lemminx.extensions.contentmodel.settings.XMLValidationSettings;
 import org.eclipse.lemminx.extensions.maven.MavenInitializationException;
 import org.eclipse.lemminx.extensions.maven.MavenLemminxExtension;
+import org.eclipse.lemminx.extensions.maven.MavenModelOutOfDatedException;
 import org.eclipse.lemminx.services.extensions.diagnostics.IDiagnosticsParticipant;
 import org.eclipse.lsp4j.Diagnostic;
 import org.eclipse.lsp4j.DiagnosticSeverity;
@@ -101,8 +102,10 @@ public class MavenDiagnosticParticipant implements IDiagnosticsParticipant {
 					node.getChildren().stream().filter(DOMElement.class::isInstance).forEach(nodes::push);
 				}
 			}
-		} catch(MavenInitializationException e) {
-			// Maven is initializing, catch the error to avoid breaking XML diagnostics from LemMinX
+		} catch (MavenInitializationException | MavenModelOutOfDatedException e) {
+			// - Maven is initializing
+			// - or parse of maven model with DOM document is out of dated
+			// -> catch the error to avoid breaking XML diagnostics from LemMinX
 		}
 	}
 

--- a/lemminx-maven/src/main/java/org/eclipse/lemminx/extensions/maven/participants/hover/MavenHoverParticipant.java
+++ b/lemminx-maven/src/main/java/org/eclipse/lemminx/extensions/maven/participants/hover/MavenHoverParticipant.java
@@ -55,6 +55,7 @@ import org.eclipse.lemminx.dom.DOMElement;
 import org.eclipse.lemminx.dom.DOMNode;
 import org.eclipse.lemminx.extensions.maven.MavenInitializationException;
 import org.eclipse.lemminx.extensions.maven.MavenLemminxExtension;
+import org.eclipse.lemminx.extensions.maven.MavenModelOutOfDatedException;
 import org.eclipse.lemminx.extensions.maven.MojoParameter;
 import org.eclipse.lemminx.extensions.maven.utils.DOMUtils;
 import org.eclipse.lemminx.extensions.maven.utils.MarkdownUtils;
@@ -91,8 +92,10 @@ public class MavenHoverParticipant extends HoverParticipantAdapter {
 			if (DOMUtils.isADescendantOf(request.getNode(), CONFIGURATION_ELT)) {
 				return collectPluginConfiguration(request, cancelChecker);
 			}
-		} catch(MavenInitializationException e) {
-			// Maven is initializing, catch the error to avoid breaking XML hover from LemMinX
+		} catch (MavenInitializationException | MavenModelOutOfDatedException e) {
+			// - Maven is initializing
+			// - or parse of maven model with DOM document is out of dated
+			// -> catch the error to avoid breaking XML hover from LemMinX
 		}
 		return null;
 	}
@@ -155,8 +158,10 @@ public class MavenHoverParticipant extends HoverParticipantAdapter {
 				// TODO consider incomplete GAV (eg plugins), by querying the "key" against project
 				default -> null;
 				};
-		} catch(MavenInitializationException e) {
-			// Maven is initializing, catch the error to avoid breaking XML hover from LemMinX
+		} catch (MavenInitializationException | MavenModelOutOfDatedException e) {
+			// - Maven is initializing
+			// - or parse of maven model with DOM document is out of dated
+			// -> catch the error to avoid breaking XML hover from LemMinX
 		}
 		return null;
 	}

--- a/lemminx-maven/src/main/java/org/eclipse/lemminx/extensions/maven/participants/rename/MavenPropertyRenameParticipant.java
+++ b/lemminx-maven/src/main/java/org/eclipse/lemminx/extensions/maven/participants/rename/MavenPropertyRenameParticipant.java
@@ -31,6 +31,7 @@ import org.eclipse.lemminx.dom.DOMNode;
 import org.eclipse.lemminx.dom.DOMText;
 import org.eclipse.lemminx.extensions.maven.MavenInitializationException;
 import org.eclipse.lemminx.extensions.maven.MavenLemminxExtension;
+import org.eclipse.lemminx.extensions.maven.MavenModelOutOfDatedException;
 import org.eclipse.lemminx.extensions.maven.utils.DOMUtils;
 import org.eclipse.lemminx.extensions.maven.utils.ParticipantUtils;
 import org.eclipse.lemminx.services.extensions.rename.IPrepareRenameRequest;
@@ -96,8 +97,10 @@ public class MavenPropertyRenameParticipant implements IRenameParticipant {
 	
 			cancelChecker.checkCanceled();
 			return properties.get(propertyName) == null ? null : Either.forLeft(propertyRange);
-		} catch(MavenInitializationException e) {
-			// Maven is initializing, catch the error to avoid breaking XML prepare rename from LemMinX
+		} catch (MavenInitializationException | MavenModelOutOfDatedException e) {
+			// - Maven is initializing
+			// - or parse of maven model with DOM document is out of dated
+			// -> catch the error to avoid breaking XML prepare rename from LemMinX
 			return null;
 		}
 	}
@@ -171,8 +174,10 @@ public class MavenPropertyRenameParticipant implements IRenameParticipant {
 						projectDocumentt.getTextDocument().getUri(), projectDocumentt.getTextDocument().getVersion());
 				renameResponse.addTextDocumentEdit(new TextDocumentEdit(projectVersionedTextDocumentIdentifier, projectTextEdits));		
 			});
-		} catch(MavenInitializationException e) {
-			// Maven is initializing, catch the error to avoid breaking XML rename from LemMinX
+		} catch (MavenInitializationException | MavenModelOutOfDatedException e) {
+			// - Maven is initializing
+			// - or parse of maven model with DOM document is out of dated
+			// -> catch the error to avoid breaking XML rename from LemMinX
 		
 		}
 	}

--- a/lemminx-maven/src/main/java/org/eclipse/lemminx/extensions/maven/utils/DOMInputStream.java
+++ b/lemminx-maven/src/main/java/org/eclipse/lemminx/extensions/maven/utils/DOMInputStream.java
@@ -15,6 +15,7 @@ import java.io.OutputStream;
 import java.util.concurrent.CancellationException;
 
 import org.eclipse.lemminx.dom.DOMDocument;
+import org.eclipse.lemminx.extensions.maven.MavenModelOutOfDatedException;
 import org.eclipse.lsp4j.jsonrpc.CancelChecker;
 
 /**
@@ -121,7 +122,9 @@ class DOMInputStream extends ByteArrayInputStream {
 
 	private void checkCanceled() {
 		if (cancelChecker != null) {
-			cancelChecker.checkCanceled();
+			if(cancelChecker.isCanceled()) {
+				throw new MavenModelOutOfDatedException();
+			}
 		}
 	}
 

--- a/lemminx-maven/src/main/java/org/eclipse/lemminx/extensions/maven/utils/MavenPluginUtils.java
+++ b/lemminx-maven/src/main/java/org/eclipse/lemminx/extensions/maven/utils/MavenPluginUtils.java
@@ -226,18 +226,13 @@ public class MavenPluginUtils {
 		
 		cancelChecker.checkCanceled();
 		if (pluginDescriptor == null && "0.0.1-SNAPSHOT".equals(plugin.getVersion())) { // probably missing or not parsed version
-			Optional<DefaultArtifactVersion> version = Optional.empty();
-			final Plugin thePlugin = plugin;
-			try {
-				version = lemminxMavenPlugin.getLocalRepositorySearcher().getLocalArtifactsLastVersion().stream()
-					.filter(gav -> thePlugin.getArtifactId().equals(gav.getArtifactId()))
-					.filter(gav -> thePlugin.getGroupId().equals(gav.getGroupId()))
-					.map(Artifact::getVersion) //
-					.map(DefaultArtifactVersion::new) //
-					.collect(Collectors.maxBy(Comparator.naturalOrder()));
-			} catch (IOException e) {
-				LOGGER.log(Level.SEVERE, e.getMessage(), e);
-			}
+			final Plugin thePlugin = plugin;			
+			Optional<DefaultArtifactVersion> version = lemminxMavenPlugin.getLocalRepositorySearcher().getLocalArtifactsLastVersion().stream()
+				.filter(gav -> thePlugin.getArtifactId().equals(gav.getArtifactId()))
+				.filter(gav -> thePlugin.getGroupId().equals(gav.getGroupId()))
+				.map(Artifact::getVersion) //
+				.map(DefaultArtifactVersion::new) //
+				.collect(Collectors.maxBy(Comparator.naturalOrder()));			
 			
 			cancelChecker.checkCanceled();
 			if (version.isPresent()) {

--- a/lemminx-maven/src/test/java/org/eclipse/lemminx/extensions/maven/InitMavenRequestTest.java
+++ b/lemminx-maven/src/test/java/org/eclipse/lemminx/extensions/maven/InitMavenRequestTest.java
@@ -35,7 +35,7 @@ public class InitMavenRequestTest {
 	
 	@BeforeAll
 	public static void setUp() {
-		MavenLemminxExtension.initializeMavenOnBackground = false;
+		MavenLemminxExtension.setUnitTestMode(true);
 	}
 	
 	@Test

--- a/lemminx-maven/src/test/java/org/eclipse/lemminx/extensions/maven/MavenProjectCacheTest.java
+++ b/lemminx-maven/src/test/java/org/eclipse/lemminx/extensions/maven/MavenProjectCacheTest.java
@@ -47,7 +47,7 @@ public class MavenProjectCacheTest {
 		String content = Files.readString(new File(uri).toPath(), StandardCharsets.UTF_8);
 		DOMDocument doc = new DOMDocument(new TextDocument(content, uri.toString()), null);
 		MavenLemminxExtension plugin = new MavenLemminxExtension();
-		plugin.initializeMavenOnBackground = false;
+		MavenLemminxExtension.setUnitTestMode(true);
 		MavenProjectCache cache = plugin.getProjectCache();
 		MavenProject project = cache.getLastSuccessfulMavenProject(doc);
 		assertNotNull(project);
@@ -60,7 +60,7 @@ public class MavenProjectCacheTest {
 		String content = Files.readString(pomFile.toPath(), StandardCharsets.UTF_8);
 		DOMDocument doc = new DOMDocument(new TextDocument(content, uri.toString()), null);
 		MavenLemminxExtension plugin = new MavenLemminxExtension();
-		plugin.initializeMavenOnBackground = false;
+		MavenLemminxExtension.setUnitTestMode(true);
 		MavenProjectCache cache = plugin.getProjectCache();
 		MavenProject project = cache.getLastSuccessfulMavenProject(doc);
 		assertNotNull(project);
@@ -70,7 +70,7 @@ public class MavenProjectCacheTest {
 	public void testParentChangeReflectedToChild()
 			throws IOException, InterruptedException, ExecutionException, URISyntaxException, Exception {
 		MavenLemminxExtension plugin = new MavenLemminxExtension();
-		plugin.initializeMavenOnBackground = false;
+		MavenLemminxExtension.setUnitTestMode(true);
 		MavenProjectCache cache = plugin.getProjectCache();
 		DOMDocument doc = getDocument("/pom-with-properties-in-parent.xml");
 		MavenProject project = cache.getLastSuccessfulMavenProject(doc);
@@ -151,7 +151,7 @@ public class MavenProjectCacheTest {
 	public void testNormilizePathsAreUsedInCache()
 			throws IOException, InterruptedException, ExecutionException, URISyntaxException, Exception {
 		MavenLemminxExtension plugin = new MavenLemminxExtension();
-		plugin.initializeMavenOnBackground = false;
+		MavenLemminxExtension.setUnitTestMode(true);
 		MavenProjectCache cache = plugin.getProjectCache();
 		
 		int initialProjectsSize = cache.getProjects().size();

--- a/lemminx-maven/src/test/java/org/eclipse/lemminx/extensions/maven/participants/completion/MavenCompletionParticipantTest.java
+++ b/lemminx-maven/src/test/java/org/eclipse/lemminx/extensions/maven/participants/completion/MavenCompletionParticipantTest.java
@@ -29,7 +29,7 @@ public class MavenCompletionParticipantTest {
 	
 	@BeforeAll
 	public static void setUp() {
-		MavenLemminxExtension.initializeMavenOnBackground = false;
+		MavenLemminxExtension.setUnitTestMode(true);
 	}
 
 	@Test


### PR DESCRIPTION
When you open a pom.xml and you trigger completion inside 

```
<dependencies>
   |
```

You should see very quickly `dependency` coming from the XSD, but it doesn't work because:

 * the local  aven searcher is initialized at this step and takes some time
 * or the parse of ModelProject throws a CancellableException which stop the completion process