### PR TITLE
Maven project cache cannot be done if one of pom.xml of the workspace doesn't define artifact id.

### DIFF
--- a/lemminx-maven/src/main/java/org/eclipse/lemminx/extensions/maven/MavenLemminxExtension.java
+++ b/lemminx-maven/src/main/java/org/eclipse/lemminx/extensions/maven/MavenLemminxExtension.java
@@ -120,7 +120,7 @@ public class MavenLemminxExtension implements IXMLExtension {
 	private static final String MAVEN_XMLLS_EXTENSION_REALM_ID = MavenLemminxExtension.class.getName();
 
 	private XMLExtensionsRegistry currentRegistry;
-	private MavenLemminxWorkspaceReader workspaceReader = new MavenLemminxWorkspaceReader(this);
+	private MavenLemminxWorkspaceReader workspaceReader = new MavenLemminxWorkspaceReader();
 	
 	private ICompletionParticipant completionParticipant;
 	private IDiagnosticsParticipant diagnosticParticipant;


### PR DESCRIPTION
Maven project cache cannot be done if one of pom.xml of the workspace
doesn't define artifact id.

If there is one pom.xml in the workspace which doesn't define an artifactid, a version or a groupdid, the call of ArtifactUtils.key and ArtifactUtils.versionLessKey throws an exception and breaks the all code.

For instance it breaks the cache of some pom.xml if ArtifactUtils.key is called with an artifcat which have no group id.