### PR TITLE
Validate dependency

### DIFF
--- a/lemminx-maven/src/main/java/org/eclipse/lemminx/extensions/maven/LoadedMavenProject.java
+++ b/lemminx-maven/src/main/java/org/eclipse/lemminx/extensions/maven/LoadedMavenProject.java
@@ -1,0 +1,87 @@
+/*******************************************************************************
+ * Copyright (c) 2023 Red Hat Inc. and others.
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+package org.eclipse.lemminx.extensions.maven;
+
+import java.util.Collection;
+
+import org.apache.maven.model.building.ModelProblem;
+import org.apache.maven.project.DependencyResolutionResult;
+import org.apache.maven.project.MavenProject;
+import org.eclipse.lemminx.dom.DOMDocument;
+
+/**
+ * Loaded maven project from:
+ * 
+ * <ul>
+ * <li>a given pom.xml file</li>
+ * <li>from a {@link DOMDocument} when the pom.xml is editing</li>
+ * </ul>
+ * 
+ * @author Angelo ZERR
+ *
+ */
+public class LoadedMavenProject {
+
+	private final MavenProject mavenProject;
+	private int lastCheckedVersion;
+	private final Collection<ModelProblem> problems;
+	private final DependencyResolutionResult dependencyResolutionResult;
+
+	public LoadedMavenProject(MavenProject mavenProject, int version, Collection<ModelProblem> problems,
+			DependencyResolutionResult dependencyResolutionResult) {
+		this.mavenProject = mavenProject;
+		this.lastCheckedVersion = version;
+		this.problems = problems;
+		this.dependencyResolutionResult = dependencyResolutionResult;
+	}
+
+	/**
+	 * Returns the loaded maven project if the pom.xml content is valid and null
+	 * otherwise.
+	 * 
+	 * @return the loaded maven project if the pom.xml content is valid and null
+	 *         otherwise.
+	 */
+	public MavenProject getMavenProject() {
+		return mavenProject;
+	}
+
+	/**
+	 * Returns the list of maven problems during the load of the pom.xml.
+	 * 
+	 * @return the list of maven problems during the load of the pom.xml.
+	 */
+	public Collection<ModelProblem> getProblems() {
+		return problems;
+	}
+
+	/**
+	 * Returns the list of dependencies which can be not resolved during the load of
+	 * the pom.xml.
+	 * 
+	 * @return the list of dependencies which can be not resolved during the load of
+	 *         the pom.xml.
+	 */
+	public DependencyResolutionResult getDependencyResolutionResult() {
+		return dependencyResolutionResult;
+	}
+
+	/**
+	 * Returns the last checked version of the document of the pom.xml.
+	 * <p>
+	 * 0 means that the loaded maven project has been loaded by a pom.xml file (it
+	 * is not editing).
+	 * </p>
+	 * 
+	 * @return the last checked version of the document of the pom.xml.
+	 */
+	public int getLastCheckedVersion() {
+		return lastCheckedVersion;
+	}
+}

--- a/lemminx-maven/src/main/java/org/eclipse/lemminx/extensions/maven/participants/diagnostics/DiagnosticRequest.java
+++ b/lemminx-maven/src/main/java/org/eclipse/lemminx/extensions/maven/participants/diagnostics/DiagnosticRequest.java
@@ -37,7 +37,7 @@ public class DiagnosticRequest implements IPositionRequest {
 	}
 
 	public Diagnostic createDiagnostic(String errorMessage, DiagnosticSeverity severity) {
-		return new Diagnostic(this.getRange(), errorMessage, severity, this.getXMLDocument().getDocumentURI(), "XML");
+		return new Diagnostic(this.getRange(), errorMessage, severity, "xml", null);
 	}
 
 	private Range getRange() {

--- a/lemminx-maven/src/test/java/org/eclipse/lemminx/extensions/maven/participants/codeaction/MavenCodeActionParticipantTest.java
+++ b/lemminx-maven/src/test/java/org/eclipse/lemminx/extensions/maven/participants/codeaction/MavenCodeActionParticipantTest.java
@@ -246,7 +246,7 @@ public class MavenCodeActionParticipantTest {
 
 		List<Diagnostic> actual = xmlLanguageService.doDiagnostics(xmlDocument, settings.getValidation(),
 				Collections.emptyMap(), () -> {
-				}).stream().filter(a -> a.getCode()!= null & a.getCode().getLeft().equals(expectedDiagnostic.getCode().getLeft()))
+				}).stream().filter(a -> a.getCode()!= null && a.getCode().getLeft() != null && a.getCode().getLeft().equals(expectedDiagnostic.getCode().getLeft()))
 				.collect(Collectors.toList());
 //		if (expected == null) {
 //			assertTrue(actual.isEmpty());

--- a/lemminx-maven/src/test/resources/pom-systemPath.xml
+++ b/lemminx-maven/src/test/resources/pom-systemPath.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <groupId>a</groupId>
   <artifactId>p</artifactId>


### PR DESCRIPTION
Validate dependency

Fixes #478

Here a basic validation when artifact is not valid. This PR could be improved because today it higlight the full artifact element. It should be nice to improve it to highlight the error for groupid, artifactid, version etc, but I think it is a good start for dependency validation.

Here a demo:

![DependencyValidator](https://github.com/eclipse/lemminx-maven/assets/1932211/5b680dd2-b2a8-4cc5-8ce0-5b82c1937875)

