### PR TITLE
Make lazy collectiing of Workspace Artifacts  in completion

### DIFF
--- a/lemminx-maven/src/main/java/org/eclipse/lemminx/extensions/maven/LoadedMavenProject.java
+++ b/lemminx-maven/src/main/java/org/eclipse/lemminx/extensions/maven/LoadedMavenProject.java
@@ -33,10 +33,9 @@ public class LoadedMavenProject {
 	private final Collection<ModelProblem> problems;
 	private final DependencyResolutionResult dependencyResolutionResult;
 
-	public LoadedMavenProject(MavenProject mavenProject, int version, Collection<ModelProblem> problems,
+	public LoadedMavenProject(MavenProject mavenProject, Collection<ModelProblem> problems,
 			DependencyResolutionResult dependencyResolutionResult) {
 		this.mavenProject = mavenProject;
-		this.lastCheckedVersion = version;
 		this.problems = problems;
 		this.dependencyResolutionResult = dependencyResolutionResult;
 	}

--- a/lemminx-maven/src/main/java/org/eclipse/lemminx/extensions/maven/LoadedMavenProjectProvider.java
+++ b/lemminx-maven/src/main/java/org/eclipse/lemminx/extensions/maven/LoadedMavenProjectProvider.java
@@ -1,0 +1,124 @@
+/*******************************************************************************
+ * Copyright (c) 2023 Red Hat Inc. and others.
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+package org.eclipse.lemminx.extensions.maven;
+
+import java.util.concurrent.CompletableFuture;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+import org.apache.maven.model.building.FileModelSource;
+import org.eclipse.lemminx.dom.DOMDocument;
+import org.eclipse.lemminx.extensions.maven.utils.DOMModelSource;
+import org.eclipse.lemminx.extensions.maven.MavenProjectCache.ProjectBuildManager;
+
+import org.eclipse.lemminx.services.IXMLDocumentProvider;
+import org.eclipse.lemminx.utils.FilesUtils;
+
+/**
+ * An object aggregating a build results of a Maven Document, controlling the 
+ * asynchronous access to the Maven Project built from the latest version of 
+ * the provided document.
+ */
+public class LoadedMavenProjectProvider {
+	private static final Logger LOGGER = Logger.getLogger(LoadedMavenProjectProvider.class.getName());
+
+	private final String uri;
+	private final IXMLDocumentProvider documentProvider;
+	private final ProjectBuildManager buildManager;
+
+	private int lastCheckedVersion;
+	private CompletableFuture<LoadedMavenProject> future;
+	
+	/**
+	 * Creates a LoadedMavenProjectProvider using provided URI String identifying the 
+	 * document to be built into a Maven Project. A document found by using Document 
+	 * Provider is the latest version of the document being currently edited or a document 
+	 * read from a file specified by document URI String.
+	 * 
+	 * @param uri A URI String identifying the document
+	 * @param documentProvider An IXMLDocumentProvider instance used to find the latest 
+	 * 		version of the document
+	 * @param buildManager A MavenProject builder
+	 */
+	public LoadedMavenProjectProvider(String uri, IXMLDocumentProvider documentProvider, ProjectBuildManager buildManager) {
+		this.uri = uri;
+		this.documentProvider = documentProvider;
+		this.buildManager = buildManager;
+		this.lastCheckedVersion = -1;
+	}
+	
+	/**
+	 * Returns a `CompletableFuture<LoadedMavenProject>` for asynchronous access
+	 * to the Maven Project built from the latest version of the document.
+	 *  
+	 * @return CompletableFuture of LoadedMavenProject object 
+	 */
+	public CompletableFuture<LoadedMavenProject> getLoadedMavenProject() {
+		DOMDocument document = documentProvider.getDocument(uri);
+		// Check if future must be created
+		// 1. is the future exist?
+		boolean shouldLoad = future == null || future.isCompletedExceptionally();
+		if (!shouldLoad) {
+			// 2. is the current future is not out of dated?
+			if (document != null) {
+				if (lastCheckedVersion !=  document.getTextDocument().getVersion()) {
+					shouldLoad = true;
+				}				
+			}
+		}
+		
+		if (shouldLoad) {
+			if (future != null) {
+				future.cancel(true);
+			}
+			if (document != null) {
+				lastCheckedVersion = document.getTextDocument().getVersion();
+			}
+			future = load(uri, document);
+		}
+		return future;
+	}
+	
+	private CompletableFuture<LoadedMavenProject> load(String uri, DOMDocument document) {
+		try {
+			FileModelSource source = null;			
+			if (document != null) {
+				source  = new DOMModelSource(document);				
+			} else {
+				source = new FileModelSource(FilesUtils.toFile(uri));
+			}
+			return buildManager.build(uri, source);
+		} catch (Exception e) {
+			LOGGER.log(Level.SEVERE, e.getMessage() + ": " + uri, e);
+			throw e;
+		}
+	}
+	
+	/**
+	 * Returns URI String identifying a Maven Project document or file
+	 * 
+	 * @return
+	 */
+	public String getUri() {
+		return uri;
+	}
+
+	/**
+	 * Returns the last checked version of the document of the pom.xml.
+	 * <p>
+	 * 0 means that the loaded maven project has been loaded by a pom.xml file (it
+	 * is not editing).
+	 * </p>
+	 * 
+	 * @return the last checked version of the document of the pom.xml.
+	 */
+	public int getLastCheckedVersion() {
+		return lastCheckedVersion;
+	}
+}

--- a/lemminx-maven/src/main/java/org/eclipse/lemminx/extensions/maven/MavenProjectCache.java
+++ b/lemminx-maven/src/main/java/org/eclipse/lemminx/extensions/maven/MavenProjectCache.java
@@ -8,18 +8,27 @@
  *******************************************************************************/
 package org.eclipse.lemminx.extensions.maven;
 
+import static org.eclipse.lemminx.extensions.maven.utils.URIUtils.toURIKey;
+import static org.eclipse.lemminx.extensions.maven.utils.URIUtils.toURIString;
+
+import java.io.EOFException;
 import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
-import java.net.URI;
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Comparator;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.concurrent.CancellationException;
-import java.util.function.Consumer;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.PriorityBlockingQueue;
+import java.util.concurrent.ThreadPoolExecutor;
+import java.util.concurrent.TimeUnit;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import java.util.stream.Collectors;
@@ -52,24 +61,429 @@ import org.codehaus.plexus.component.repository.exception.ComponentLookupExcepti
 import org.codehaus.plexus.util.xml.pull.XmlPullParserException;
 import org.eclipse.lemminx.dom.DOMDocument;
 import org.eclipse.lemminx.extensions.maven.utils.DOMModelSource;
+import org.eclipse.lemminx.services.IXMLDocumentProvider;
+import org.eclipse.lsp4j.jsonrpc.CancelChecker;
+import org.eclipse.lsp4j.jsonrpc.CompletableFutures.FutureCancelChecker;
 
 public class MavenProjectCache {
 
 	private static final Logger LOGGER = Logger.getLogger(MavenProjectCache.class.getName());
-	private final Map<URI, LoadedMavenProject> projectCache;
+	private final Map<String, LoadedMavenProjectProvider> projectCache;
 	private final MavenSession mavenSession;
+	private final IXMLDocumentProvider documentProvider;
 
-	MavenXpp3Reader mavenReader = new MavenXpp3Reader();
-	private ProjectBuilder projectBuilder;
+	private ProjectBuildManager projectBuildManager;
 
-	private final List<Consumer<MavenProject>> projectParsedListeners = new ArrayList<>();
-
-	public MavenProjectCache(MavenSession mavenSession) {
+	public MavenProjectCache(MavenSession mavenSession, IXMLDocumentProvider documentProvider) {
 		this.mavenSession = mavenSession;
 		this.projectCache = new HashMap<>();
-		initializeMavenBuildState();
+		this.documentProvider = documentProvider;
+		this.projectBuildManager = new ProjectBuildManager();
 	}
 
+	/**
+	 * Should be called when Maven Lemminx Extension initialization 
+	 * is successfully finished
+	 */
+	public void start() {
+		projectBuildManager.start();
+	}
+
+	public void stop() {
+		projectBuildManager.stop();
+	}
+	
+	class ProjectBuildManager {
+		private static final int CORE_POOL_SIZE = 10;
+
+		private Map<Object, BuildProjectRunnable> toProcess = new HashMap<>();
+		private final PriorityBlockingQueue</*Runnable*/Runnable> runnables = new PriorityBlockingQueue<>(1, PRIORITIZED_DEEPEST_FIRST);
+		private final ThreadPoolExecutor executor = new ThreadPoolExecutor(0, 1, 0, TimeUnit.MILLISECONDS, runnables);
+		private final MavenXpp3Reader mavenReader = new MavenXpp3Reader();
+		private ProjectBuilder projectBuilder;
+
+		private final class BuildProjectRunnable implements Runnable {
+			final String uri;
+			final FileModelSource source;
+			final CompletableFuture<LoadedMavenProject> future;
+			private int priority;
+
+			private BuildProjectRunnable(String uri, FileModelSource source) {
+				this.uri = uri;
+				this.source = source;
+				this.future = new CompletableFuture<>();
+				this.priority = 0;
+			}
+			
+			int getPriority() {
+				return this.priority;
+			}
+			
+			void bumpPriority() {
+				this.priority++;
+			}
+
+			@Override
+			public void run() {
+				try {
+					future.complete(build(source, new FutureCancelChecker(future)));
+				} catch (Exception e) { // This should include CancellationException
+					future.completeExceptionally(e);
+				}
+			}
+
+			@Override
+			public boolean equals(Object obj) {
+				if (super.equals(obj)) {
+					return true;
+				}
+				if (obj instanceof BuildProjectRunnable runnable) {
+					return this.hashCode() == runnable.hashCode();
+				}
+				return false;
+			}
+
+			@Override
+			public int hashCode() {
+				return Objects.hash(toURIKey(uri), source);
+			}
+
+			public LoadedMavenProject build(FileModelSource source, CancelChecker cancelChecker) {
+				Collection<ModelProblem> problems = new ArrayList<>();
+				DependencyResolutionResult dependencyResolutionResult = null;
+				MavenProject project = null;
+				File file = source.getFile();
+				try {			
+					ProjectBuildingResult buildResult = projectBuilder.build(source, newProjectBuildingRequest());
+					cancelChecker.checkCanceled();
+					project = buildResult.getProject();
+					problems.addAll(buildResult.getProblems());
+					dependencyResolutionResult = buildResult.getDependencyResolutionResult();
+
+					if (project != null) {
+						// setFile should ideally be invoked during project build, but related methods
+						// to pass modelSource and pomFile are private
+						project.setFile(file);
+					}
+				} catch (ProjectBuildingException e) {
+					if (e.getResults() == null) {
+						if (e.getCause() instanceof ModelBuildingException modelBuildingException) {
+							// Try to manually build a minimal project from the document to collect
+							// lower-level
+							// errors and to have something usable in cache for most basic operations
+							modelBuildingException.getProblems().stream()
+									.filter(p -> !(p.getException() instanceof ModelParseException)).forEach(problems::add);
+							try (InputStream documentStream = source.getInputStream()) {
+								Model model = mavenReader.read(documentStream);
+								cancelChecker.checkCanceled();
+								project = new MavenProject(model);
+								project.setRemoteArtifactRepositories(model.getRepositories().stream()
+										.map(repo -> new MavenArtifactRepository(repo.getId(), repo.getUrl(),
+												new DefaultRepositoryLayout(),
+												new ArtifactRepositoryPolicy(true,
+														ArtifactRepositoryPolicy.UPDATE_POLICY_INTERVAL,
+														ArtifactRepositoryPolicy.CHECKSUM_POLICY_WARN),
+												new ArtifactRepositoryPolicy(true,
+														ArtifactRepositoryPolicy.UPDATE_POLICY_INTERVAL,
+														ArtifactRepositoryPolicy.CHECKSUM_POLICY_WARN)))
+										.distinct().collect(Collectors.toList()));
+								project.setFile(file);
+								project.setBuild(new Build());
+							} catch (XmlPullParserException | EOFException parserException) {
+								// XML document is invalid for parsing (eg user is typing), it's a valid state
+								// that shouldn't log
+								// exceptions
+							} catch (IOException ex) {
+								// Log at low severity for debugging purposes
+								LOGGER.log(Level.FINER, e.getMessage(), e);
+							}
+						} else {
+							problems.add(
+									new DefaultModelProblem(e.getMessage(), Severity.FATAL, Version.BASE, null, -1, -1, e));
+						}
+					} else {
+						e.getResults().stream().flatMap(result -> result.getProblems().stream()).forEach(problems::add);
+						if (e.getResults().size() == 1) {
+							project = e.getResults().get(0).getProject();
+							if (project != null) {
+								project.setFile(file);
+							}
+						}
+					}
+				} catch (CancellationException e) {
+					// The document which has been used to load Maven project is out of dated
+					throw e;
+				} catch (Exception e) {
+					// Do not add any info, like lastCheckedVersion or problems, to the cache
+					// In case of project/problems etc. is not available due to an exception
+					// happened.
+					//
+					LOGGER.log(Level.SEVERE, e.getMessage(), e);
+					return null; // Nothing to be cached
+				}
+				return new LoadedMavenProject(project, problems, dependencyResolutionResult);
+			}
+		}
+
+		private ProjectBuildManager() {
+			initializeMavenBuildState();
+		}
+
+		private static final Object runnableKey(String uri, FileModelSource source) {
+			return Integer.valueOf(Objects.hash(uri, source));
+		}
+		
+		private void initializeMavenBuildState() {
+			if (projectBuilder != null) {
+				return;
+			}
+			try {
+				projectBuilder = getPlexusContainer().lookup(ProjectBuilder.class);
+				System.setProperty(DefaultProjectBuilder.DISABLE_GLOBAL_MODEL_CACHE_SYSTEM_PROPERTY,
+						Boolean.toString(true));
+			} catch (ComponentLookupException e) {
+				LOGGER.log(Level.SEVERE, e.getMessage(), e);
+			}
+		}
+		
+		private void start() {
+			if (executor.getCorePoolSize() == 0) {
+				executor.setCorePoolSize(CORE_POOL_SIZE);
+			}
+		}
+
+		private void stop() {
+			if (executor.getCorePoolSize() > 0) {
+				executor.setCorePoolSize(0);
+			}
+			executor.shutdown();
+		}
+
+		private static final Comparator<Runnable> PRIORITIZED_DEEPEST_FIRST = (o1, o2) -> {
+			if (!(o1 instanceof BuildProjectRunnable r1 && o2 instanceof BuildProjectRunnable r2)) {
+				return 0;
+			}
+			int result = Comparator.comparingInt(BuildProjectRunnable::getPriority)
+					.compare(r1, r2);
+			if (result == 0) {
+				result = r1.uri.compareTo(r2.uri);
+			}
+			return result;
+		};
+		
+		/**
+		 * Asynchronously builds a provided document from a source provided
+		 * 
+		 * @param uri An URI String identifying the document ro be built
+		 * @param source A FIleModelSource for the document to be built
+		 * @return A CompletableFuture of LoadedMavenProject object
+		 */
+		public CompletableFuture<LoadedMavenProject> build(final String uri, final FileModelSource source) {
+			BuildProjectRunnable runnable = null;
+			Object key = runnableKey(toURIKey(uri), source);
+			synchronized (toProcess) {
+				runnable = toProcess.get(key);
+				if (runnable != null) {
+					// Project is already queued to be built, so just bump the 
+					// runnable priority to force build to be started earlier.
+					runnable.bumpPriority();
+				} else {
+					runnable = new BuildProjectRunnable(uri, source);
+					toProcess.put(key, runnable);
+					executor.execute(runnable);
+					runnable.future.whenComplete((ok, error) -> toProcess.remove(key));
+				}
+			}
+			return runnable.future;
+		}
+
+		/**
+		 * Returns a cached MavenProject object or builds a new one from a file source
+		 * The resulting MavenProject is a snapshot that is not to be cached (unless it's 
+		 * taken from Maven Project Cache)
+		 * 
+		 * @param file of Maven Project to be built
+		 * @return Optional of MavenProject object
+		 */
+		public Optional<MavenProject> getSnapshotProject(File file) {
+			LoadedMavenProjectProvider projectProvider = projectCache.get(toURIKey(file));
+			Integer last = projectProvider != null ? projectProvider.getLastCheckedVersion() : null;
+			if (last != null && last.intValue() >= 0) {
+				LoadedMavenProject loadedProject = projectProvider.getLoadedMavenProject().getNow(null);
+				MavenProject project = loadedProject != null ? loadedProject.getMavenProject() : null;
+				if (project != null) {
+					return Optional.of(project);
+				}
+			}
+
+			try {
+				return Optional.of(projectBuilder.build(file, newProjectBuildingRequest()).getProject());
+			} catch (ProjectBuildingException e) {
+				List<ProjectBuildingResult> result = e.getResults();
+				if (result != null && result.size() == 1 && result.get(0).getProject() != null) {
+					return Optional.of(result.get(0).getProject());
+				}
+			} catch (Exception e) {
+				// Some other kinds of exceptions may be thrown, for instance,
+				// an IllegalStateException in case of fail to acquire write lock for an
+				// artifact
+				LOGGER.log(Level.SEVERE, e.getMessage(), e);
+			}
+
+			return Optional.empty();
+		}
+
+		/**
+		 * Builds the MavenProject object from a Document being edited using a given Profile ID.
+		 * The resulting MavenProject is a snapshot that is not to be cached
+		 * 
+		 * @param document Maven Project DOMDocument to be built
+		 * @param profileId A profile ID to be used on builf
+		 * @param resolve a boolean indicating if dependencies are to be resolved during the build
+		 * @return Optional of MavenProject object
+		 */
+		public MavenProject getSnapshotProject(DOMDocument document, String profileId, boolean resolve) {
+			// it would be nice to directly rebuild from Model instead of re-parsing text
+			ProjectBuildingRequest request = newProjectBuildingRequest(resolve);
+			if (profileId != null) {
+				request.setActiveProfileIds(List.of(profileId));
+			}
+			try {
+				DOMModelSource source = new DOMModelSource(document);
+				return projectBuilder.build(source, request).getProject();
+			} catch (CancellationException e) {
+				// The document which has been used to load Maven project is out of dated
+				throw e;
+			} catch (ProjectBuildingException e) {
+				List<ProjectBuildingResult> result = e.getResults();
+				if (result != null && result.size() == 1 && result.get(0).getProject() != null) {
+					return result.get(0).getProject();
+				}
+			} catch (Exception e) {
+				e.printStackTrace();
+			}
+			return null;
+		}
+
+		/**
+		 * Creates a new default Maven Project Building request (with dependency 
+		 * resolve enabled) 
+		 * 
+		 * @return A ProjectBuildingRequest object
+		 */
+		public ProjectBuildingRequest newProjectBuildingRequest() {
+			return newProjectBuildingRequest(true);
+		}
+		
+		/**
+		 * Creates a new default Maven Project Building request
+		 * 
+		 * @param resolveDependencies a boolean indicating if the dependency 
+		 * resolve is to be enabled on the request.
+		 * 
+		 * @return A ProjectBuildingRequest object
+		 */
+		public ProjectBuildingRequest newProjectBuildingRequest(boolean resolveDependencies) {
+			ProjectBuildingRequest request = new DefaultProjectBuildingRequest();
+			MavenExecutionRequest mavenRequest = mavenSession.getRequest();
+			request.setSystemProperties(mavenRequest.getSystemProperties());
+			request.setLocalRepository(mavenRequest.getLocalRepository());
+			request.setRemoteRepositories(mavenRequest.getRemoteRepositories());
+			request.setPluginArtifactRepositories(mavenRequest.getPluginArtifactRepositories());
+			// TODO more to transfer from mavenRequest to ProjectBuildingRequest?
+			request.setRepositorySession(mavenSession.getRepositorySession());
+			request.setResolveDependencies(resolveDependencies);
+
+			// See: https://issues.apache.org/jira/browse/MRESOLVER-374
+			request.getUserProperties().setProperty("aether.syncContext.named.factory", "noop");
+			return request;
+		}
+	}
+
+	/**
+	 * Returns the PlexusContainer object used in Maven Session
+	 * 
+	 * @return A PlexusComtainer object
+	 */
+	public PlexusContainer getPlexusContainer() {
+		return mavenSession.getContainer();
+	}
+
+	/**
+	 * Returns the list of built Maven Projects currently available in the 
+	 * Maven Project Cache
+	 * 
+	 * @return A Collection of currently available Maven Projects
+	 */
+	public Collection<MavenProject> getProjects() {
+		return projectCache.values().stream()
+				.map(LoadedMavenProjectProvider::getLoadedMavenProject)
+				.map(f -> f.getNow(null)).filter(Objects::nonNull)
+				.map(LoadedMavenProject::getMavenProject)
+				.toList();
+	}
+
+	/**
+	 * Returns the last successfully parsed and cached Maven Project for the
+	 * given POM file if exists or builds a Snapshot Maven Project (not caching 
+	 * the Maven Project build results, nor saving the build problems if any)
+	 * 
+	 * @param file
+	 * @return Optional Maven Project
+	 */
+	public Optional<MavenProject> getSnapshotProject(File file) {
+		return projectBuildManager.getSnapshotProject(file);
+	}
+	
+	/**
+	 * Returns the successfully parsed Maven Project built from the given 
+	 * document (not caching the Maven Project build results, nor saving 
+	 * the build problems if any)
+	 * 
+	 * @param document
+	 * @param profileId 
+	 * @return Optional Maven Project
+	 */
+	public MavenProject getSnapshotProject(DOMDocument document, String profileId) {
+		return getSnapshotProject(document, profileId, true);
+	}
+
+	/**
+	 * Returns the successfully parsed Maven Project built from the given 
+	 * document (not caching the Maven Project build results, nor saving 
+	 * the build problems if any)
+	 * 
+	 * @param document
+	 * @param profileId 
+	 * @param resolve
+	 * @return Optional Maven Project
+	 */
+	public MavenProject getSnapshotProject(DOMDocument document, String profileId, boolean resolve) {
+		return projectBuildManager.getSnapshotProject(document, profileId, resolve);
+	}
+
+	/**
+	 * Returns the last successfully parsed and cached Maven Project for the 
+	 * given POM file if exists and up to date
+	 * 
+	 * @param pomFile A given POM File
+	 * @return the last MavenDocument that could be build for the more recent
+	 *         version of the provided document. If document fails to build a
+	 *         MavenProject, a former version will be returned. Can be
+	 *         <code>null</code>.
+	 */
+	public MavenProject getLastSuccessfulMavenProject(File pomFile) {
+		CompletableFuture<LoadedMavenProject> project = getLoadedMavenProject(pomFile);
+		try {
+			return project != null ? project.get().getMavenProject() : null;
+		} catch (InterruptedException e) {
+			Thread.currentThread().interrupt();
+		} catch (ExecutionException e) {
+			LOGGER.log(Level.SEVERE, e.getMessage(), e);
+		}
+		return null;
+	}
+	
 	/**
 	 * Returns the last successfully parsed and cached Maven Project for the given
 	 * document
@@ -81,248 +495,62 @@ public class MavenProjectCache {
 	 *         <code>null</code>.
 	 */
 	public MavenProject getLastSuccessfulMavenProject(DOMDocument document) {
-		check(document);
-		LoadedMavenProject project = getLoadedMavenProject(document.getTextDocument().getUri());
-		return project != null ? project.getMavenProject() : null;
-	}
-
-	/**
-	 * Returns the last successfully parsed and cached Maven Project for the given
-	 * POM file
-	 * 
-	 * @param pomFile A given POM File
-	 * @return the last MavenDocument that could be build for the more recent
-	 *         version of the provided document. If document fails to build a
-	 *         MavenProject, a former version will be returned. Can be
-	 *         <code>null</code>.
-	 */
-	public MavenProject getLastSuccessfulMavenProject(File pomFile) {
-		check(pomFile);
-		LoadedMavenProject project = getLoadedMavenProject(pomFile.toURI());
-		return project != null ? project.getMavenProject() : null;
-	}
-
-	/**
-	 *
-	 * @param document
-	 * @return the problems for the latest version of the document (either in cache,
-	 *         or the one passed in arguments)
-	 */
-	public LoadedMavenProject getLoadedMavenProject(DOMDocument document) {
-		check(document);
-		return getLoadedMavenProject(document.getTextDocument().getUri());
-	}
-
-	private void check(DOMDocument document) {
-		LoadedMavenProject project = getLoadedMavenProject(document.getTextDocument().getUri());
-		Integer last = project != null ? project.getLastCheckedVersion() : null;
-		if (last == null || last.intValue() < document.getTextDocument().getVersion()) {
-			parseAndCache(document);
-		}
-	}
-
-	private void check(File pomFile) {
-		LoadedMavenProject project = getLoadedMavenProject(pomFile.toURI());
-		Integer last = project != null ? project.getLastCheckedVersion() : null;
-		if (last == null || last.intValue() < 0) {
-			parseAndCache(pomFile);
-		}
-	}
-
-	public Optional<MavenProject> getSnapshotProject(File file) {
-		LoadedMavenProject loadedProject = getLoadedMavenProject(file.toURI());
-		MavenProject lastKnownVersionMavenProject = loadedProject != null ? loadedProject.getMavenProject() : null;
-		if (lastKnownVersionMavenProject != null) {
-			return Optional.of(lastKnownVersionMavenProject);
-		}
+		CompletableFuture<LoadedMavenProject> project = getLoadedMavenProject(document);
 		try {
-			MavenProject project = projectBuilder.build(file, newProjectBuildingRequest()).getProject();
-			return Optional.of(project);
-		} catch (ProjectBuildingException e) {
-			List<ProjectBuildingResult> result = e.getResults();
-			if (result != null && result.size() == 1 && result.get(0).getProject() != null) {
-				MavenProject project = result.get(0).getProject();
-				return Optional.of(project);
-			}
-		} catch (Exception e) {
-			// Some other kinds of exceptions may be thrown, for instance,
-			// an IllegalStateException in case of fail to acquire write lock for an
-			// artifact
+			return project != null ? project.get().getMavenProject() : null;
+		} catch (InterruptedException e) {
+			Thread.currentThread().interrupt();
+		} catch (ExecutionException e) {
 			LOGGER.log(Level.SEVERE, e.getMessage(), e);
-		}
-
-		return Optional.empty();
-	}
-
-	private void parseAndCache(URI uri, int version, FileModelSource source) {
-		Collection<ModelProblem> problems = new ArrayList<>();
-		DependencyResolutionResult dependencyResolutionResult = null;
-		uri = uri.normalize();
-		final File file = new File(uri);
-		MavenProject project = null;
-		try {
-			ProjectBuildingResult buildResult = projectBuilder.build(source, newProjectBuildingRequest());
-			project = buildResult.getProject();
-			problems.addAll(buildResult.getProblems());
-			dependencyResolutionResult = buildResult.getDependencyResolutionResult();
-
-			if (project != null) {
-				// setFile should ideally be invoked during project build, but related methods
-				// to pass modelSource and pomFile are private
-				project.setFile(new File(uri));
-			}
-		} catch (ProjectBuildingException e) {
-			if (e.getResults() == null) {
-				if (e.getCause() instanceof ModelBuildingException modelBuildingException) {
-					// Try to manually build a minimal project from the document to collect
-					// lower-level
-					// errors and to have something usable in cache for most basic operations
-					modelBuildingException.getProblems().stream()
-							.filter(p -> !(p.getException() instanceof ModelParseException)).forEach(problems::add);
-					try (InputStream documentStream = source.getInputStream()) {
-						Model model = mavenReader.read(documentStream);
-						project = new MavenProject(model);
-						project.setRemoteArtifactRepositories(model.getRepositories().stream()
-								.map(repo -> new MavenArtifactRepository(repo.getId(), repo.getUrl(),
-										new DefaultRepositoryLayout(),
-										new ArtifactRepositoryPolicy(true,
-												ArtifactRepositoryPolicy.UPDATE_POLICY_INTERVAL,
-												ArtifactRepositoryPolicy.CHECKSUM_POLICY_WARN),
-										new ArtifactRepositoryPolicy(true,
-												ArtifactRepositoryPolicy.UPDATE_POLICY_INTERVAL,
-												ArtifactRepositoryPolicy.CHECKSUM_POLICY_WARN)))
-								.distinct().collect(Collectors.toList()));
-						project.setFile(file);
-						project.setBuild(new Build());
-					} catch (XmlPullParserException parserException) {
-						// XML document is invalid fo parsing (eg user is typing), it's a valid state
-						// that shouldn't log
-						// exceptions
-					} catch (IOException ex) {
-						LOGGER.log(Level.SEVERE, e.getMessage(), e);
-					}
-				} else {
-					problems.add(
-							new DefaultModelProblem(e.getMessage(), Severity.FATAL, Version.BASE, null, -1, -1, e));
-				}
-			} else {
-				e.getResults().stream().flatMap(result -> result.getProblems().stream()).forEach(problems::add);
-				if (e.getResults().size() == 1) {
-					project = e.getResults().get(0).getProject();
-					if (project != null) {
-						project.setFile(new File(uri));
-					}
-				}
-			}
-		} catch (CancellationException e) {
-			// The document which has been used to load Maven project is out of dated
-			throw e;
-		} catch (Exception e) {
-			// Do not add any info, like lastCheckedVersion or problems, to the cache
-			// In case of project/problems etc. is not available due to an exception
-			// happened.
-			//
-			LOGGER.log(Level.SEVERE, e.getMessage(), e);
-			return; // Nothing to be cached
-		}
-
-		cacheProject(project, file, uri, version, problems, dependencyResolutionResult);
-	}
-
-	private void cacheProject(final MavenProject project, File file, URI uri, int version,
-			Collection<ModelProblem> problems, DependencyResolutionResult dependencyResolutionResult) {
-		LoadedMavenProject loadedProject = new LoadedMavenProject(project, version, problems,
-				dependencyResolutionResult);
-		if (project != null) {
-			projectParsedListeners.forEach(listener -> listener.accept(project));
-		}
-		projectCache.put(uri, loadedProject);
-	}
-
-	private void parseAndCache(DOMDocument document) {
-		URI uri = URI.create(document.getDocumentURI()).normalize();
-		int version = document.getTextDocument().getVersion();
-		DOMModelSource source = new DOMModelSource(document);
-		parseAndCache(uri, version, source);
-	}
-
-	private void parseAndCache(File pomFile) {
-		URI uri = pomFile.toURI().normalize();
-		FileModelSource source = new FileModelSource(pomFile);
-		parseAndCache(uri, 0, source);
-	}
-
-	private ProjectBuildingRequest newProjectBuildingRequest() {
-		return newProjectBuildingRequest(true);
-	}
-
-	private ProjectBuildingRequest newProjectBuildingRequest(boolean resolveDependencies) {
-		ProjectBuildingRequest request = new DefaultProjectBuildingRequest();
-		MavenExecutionRequest mavenRequest = mavenSession.getRequest();
-		request.setSystemProperties(mavenRequest.getSystemProperties());
-		request.setLocalRepository(mavenRequest.getLocalRepository());
-		request.setRemoteRepositories(mavenRequest.getRemoteRepositories());
-		request.setPluginArtifactRepositories(mavenRequest.getPluginArtifactRepositories());
-		// TODO more to transfer from mavenRequest to ProjectBuildingRequest?
-		request.setRepositorySession(mavenSession.getRepositorySession());
-		request.setResolveDependencies(resolveDependencies);
-
-		// See: https://issues.apache.org/jira/browse/MRESOLVER-374
-		request.getUserProperties().setProperty("aether.syncContext.named.factory", "noop");
-		return request;
-	}
-
-	private void initializeMavenBuildState() {
-		if (projectBuilder != null) {
-			return;
-		}
-		try {
-			projectBuilder = getPlexusContainer().lookup(ProjectBuilder.class);
-			System.setProperty(DefaultProjectBuilder.DISABLE_GLOBAL_MODEL_CACHE_SYSTEM_PROPERTY,
-					Boolean.toString(true));
-		} catch (ComponentLookupException e) {
-			LOGGER.log(Level.SEVERE, e.getMessage(), e);
-		}
-	}
-
-	public PlexusContainer getPlexusContainer() {
-		return mavenSession.getContainer();
-	}
-
-	public Collection<MavenProject> getProjects() {
-		return projectCache.values().stream().map(LoadedMavenProject::getMavenProject).toList();
-	}
-
-	public MavenProject getSnapshotProject(DOMDocument document, String profileId) {
-		return getSnapshotProject(document, profileId, true);
-	}
-
-	public MavenProject getSnapshotProject(DOMDocument document, String profileId, boolean resolveDependencies) {
-		// it would be nice to directly rebuild from Model instead of reparsing text
-		ProjectBuildingRequest request = newProjectBuildingRequest(resolveDependencies);
-		if (profileId != null) {
-			request.setActiveProfileIds(List.of(profileId));
-		}
-		try {
-			DOMModelSource source = new DOMModelSource(document);
-			return projectBuilder.build(source, request).getProject();
-		} catch (CancellationException e) {
-			// The document which has been used to load Maven project is out of dated
-			throw e;
-		} catch (ProjectBuildingException e) {
-			List<ProjectBuildingResult> result = e.getResults();
-			if (result != null && result.size() == 1 && result.get(0).getProject() != null) {
-				return result.get(0).getProject();
-			}
 		}
 		return null;
 	}
 
-	private LoadedMavenProject getLoadedMavenProject(String uri) {
-		return getLoadedMavenProject(URI.create(uri));
+	/**
+	 * Returns a Completable Future of Loaded Maven Project for the given
+	 * file
+	 * 
+	 * @param file A POM file
+	 * @return Completable Future of LoadedMavenDocument that could be build for 
+	 * 		the most recent version of the provided file.
+	 */
+	public CompletableFuture<LoadedMavenProject> getLoadedMavenProject(File pomFile) {
+		return getLoadedMavenProject(toURIString(pomFile));
 	}
-
-	private LoadedMavenProject getLoadedMavenProject(URI uri) {
-		return projectCache.get(uri.normalize());
+	
+	/**
+	 * Returns a Completable Future of Loaded Maven Project for the given
+	 * document
+	 * 
+	 * @param file A DOMDocument 
+	 * @return Completable Future of LoadedMavenDocument that could be build for 
+	 * 		the most recent version of the provided document.
+	 */
+	public CompletableFuture<LoadedMavenProject> getLoadedMavenProject(DOMDocument document) {
+		return getLoadedMavenProject(document.getDocumentURI());
+	}
+	
+	/**
+	 * Returns a Completable Future of Loaded Maven Project for the given
+	 * URI String document identifier 
+	 * 
+	 * @param uriString A document URI String
+	 * @return Completable Future of LoadedMavenDocument that could be build for 
+	 * 		the most recent version of the document represented by the specified 
+	 * 		URI String identifier.
+	 */
+	public CompletableFuture<LoadedMavenProject> getLoadedMavenProject(String uriString) {
+		String uriKey = toURIKey(uriString);
+		LoadedMavenProjectProvider provider = projectCache.get(uriKey);
+		if (provider == null) {
+			synchronized (projectCache) {
+				provider = projectCache.get(uriKey);
+				if (provider == null) {
+					provider = new LoadedMavenProjectProvider(uriString, documentProvider, projectBuildManager);
+					projectCache.put(uriKey, provider);
+				}
+			}
+		}
+		return provider.getLoadedMavenProject();
 	}
 }

--- a/lemminx-maven/src/main/java/org/eclipse/lemminx/extensions/maven/participants/hover/MavenHoverParticipant.java
+++ b/lemminx-maven/src/main/java/org/eclipse/lemminx/extensions/maven/participants/hover/MavenHoverParticipant.java
@@ -487,7 +487,7 @@ public class MavenHoverParticipant extends HoverParticipantAdapter {
 		Set<MojoParameter> parameters;
 		cancelChecker.checkCanceled();
 		try {
-			parameters = MavenPluginUtils.collectPluginConfigurationMojoParameters(request, plugin);
+			parameters = MavenPluginUtils.collectPluginConfigurationMojoParameters(request, plugin, cancelChecker);
 		} catch (PluginResolutionException | PluginDescriptorParsingException | InvalidPluginDescriptorException e) {
 			LOGGER.log(Level.SEVERE, e.getMessage(), e);
 			return null;

--- a/lemminx-maven/src/main/java/org/eclipse/lemminx/extensions/maven/participants/rename/MavenPropertyRenameParticipant.java
+++ b/lemminx-maven/src/main/java/org/eclipse/lemminx/extensions/maven/participants/rename/MavenPropertyRenameParticipant.java
@@ -148,7 +148,7 @@ public class MavenPropertyRenameParticipant implements IRenameParticipant {
 			cancelChecker.checkCanceled();
 			LinkedHashSet<MavenProject> projects = new LinkedHashSet<>();
 			projects.add(thisProject);
-			plugin.getCurrentWorkspaceProjects().stream().forEach(child -> 
+			plugin.getCurrentWorkspaceProjects(true).stream().forEach(child -> 
 				projects.addAll(findParentsOfChildProject(thisProject, child)));
 	
 			URI thisProjectUri = ParticipantUtils.normalizedUri(document.getDocumentURI());
@@ -178,7 +178,6 @@ public class MavenPropertyRenameParticipant implements IRenameParticipant {
 			// - Maven is initializing
 			// - or parse of maven model with DOM document is out of dated
 			// -> catch the error to avoid breaking XML rename from LemMinX
-		
 		}
 	}
 

--- a/lemminx-maven/src/main/java/org/eclipse/lemminx/extensions/maven/utils/DOMModelSource.java
+++ b/lemminx-maven/src/main/java/org/eclipse/lemminx/extensions/maven/utils/DOMModelSource.java
@@ -8,14 +8,14 @@
  *******************************************************************************/
 package org.eclipse.lemminx.extensions.maven.utils;
 
-import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
-import java.net.URI;
+import java.util.Objects;
 
 import org.apache.maven.model.building.FileModelSource;
 import org.apache.maven.model.building.ModelSource;
 import org.eclipse.lemminx.dom.DOMDocument;
+import org.eclipse.lemminx.utils.FilesUtils;
 
 /**
  * A Maven {@link ModelSource} implementation based on LemMinx
@@ -33,12 +33,17 @@ public class DOMModelSource extends FileModelSource {
 	private final DOMDocument document;
 
 	public DOMModelSource(DOMDocument document) {
-		super(new File(URI.create(document.getDocumentURI()).normalize()));
+		super(FilesUtils.toFile(document.getDocumentURI()));
 		this.document = document;
 	}
 
 	@Override
 	public InputStream getInputStream() throws IOException {
 		return new DOMInputStream(document);
+	}
+	
+	@Override
+	public int hashCode() {
+		return Objects.hash(getFile(), document.getTextDocument().getVersion());
 	}
 }

--- a/lemminx-maven/src/main/java/org/eclipse/lemminx/extensions/maven/utils/URIUtils.java
+++ b/lemminx-maven/src/main/java/org/eclipse/lemminx/extensions/maven/utils/URIUtils.java
@@ -1,0 +1,185 @@
+/*******************************************************************************
+ * Copyright (c) 2023 Red Hat Inc. and others.
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+package org.eclipse.lemminx.extensions.maven.utils;
+
+import java.io.ByteArrayOutputStream;
+import java.io.File;
+import java.io.UnsupportedEncodingException;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+import org.eclipse.lemminx.dom.DOMDocument;
+
+public class URIUtils {
+	private static final Logger LOGGER = Logger.getLogger(URIUtils.class.getName());
+
+	/**
+	 * Returns an URI String identifying a specified document
+	 * 
+	 * @param document A Maven Project document
+	 * @return URI String identificator
+	 */
+	public static String toURIString(DOMDocument document) {
+		return document.getDocumentURI();
+	}
+
+	/**
+	 * Returns an URI String identifying a specified POM file
+	 * 
+	 * @param file A POM file
+	 * @return URI String identificator
+	 */
+	public static String toURIString(File file) {
+		return toUri(file).toASCIIString();
+	}
+
+	/**
+	 * Returns an URI String key for a specified document to be used to store
+	 * a Maven Project document information in a map
+	 * 
+	 * @param document A Maven Project document
+	 * @return URI String key
+	 */
+	public static String toURIKey(DOMDocument document) {
+		return toURIKey(toURIString(document));
+	}
+	
+	/**
+	 * Returns an URI String key for a specified URI String identificator to be 
+	 * used to store a Maven Project document information in a map
+	 * 
+	 * @param uriString URI String identificator
+	 * @return URI String key
+	 */
+	public static String toURIKey(String uriString) {
+		String normalizedURI = URI.create(uriString).normalize().toASCIIString() ;
+		return URIUtils.encodeFileURI(normalizedURI, StandardCharsets.UTF_8)
+				.toUpperCase();
+	}
+	
+	/**
+	 * Returns an URI String key for a specified POM file to be used to store
+	 * a Maven Project document information in a map
+	 * 
+	 * @param file POM file
+	 * @return URI String key
+	 */
+	public static String toURIKey(File file) {
+		return toURIString(file).toUpperCase();
+	}
+	
+	// Copied from https://github.com/eclipse/lsp4e/blob/master/org.eclipse.lsp4e/src/org/eclipse/lsp4e/LSPEclipseUtils.java
+	private static URI toUri(File file) {
+		// URI scheme specified by language server protocol and LSP
+		try {
+			return new URI("file", "", file.getAbsoluteFile().toURI().getPath(), null); //$NON-NLS-1$ //$NON-NLS-2$
+		} catch (URISyntaxException e) {
+			LOGGER.log(Level.SEVERE, e.getMessage(), e);
+			return file.getAbsoluteFile().toURI();
+		}
+	}
+	
+	// Copied from https://github.com/eclipse/lsp4mp/blob/master/microprofile.ls/org.eclipse.lsp4mp.ls/src/main/java/org/eclipse/lsp4mp/utils/URIUtils.java
+	private static String encodeFileURI(String source, Charset charset) {
+		String fileScheme = "";
+		int index = -1;
+		if (source.startsWith("file://")) {
+			index = 6;
+			if (source.charAt(7) == '/') {
+				index = 7;
+			}
+		}
+		if (index != -1) {
+			fileScheme = source.substring(0, index + 1);
+			source = source.substring(index + 1, source.length());
+		}
+
+		byte[] bytes = source.getBytes(charset);
+		boolean original = true;
+		for (byte b : bytes) {
+			if (!isAllowed(b)) {
+				original = false;
+				break;
+			}
+		}
+		if (original) {
+			return source;
+		}
+
+		ByteArrayOutputStream baos = new ByteArrayOutputStream(bytes.length);
+		for (byte b : bytes) {
+			if (isAllowed(b)) {
+				baos.write(b);
+			} else {
+				baos.write('%');
+				char hex1 = Character.toUpperCase(Character.forDigit((b >> 4) & 0xF, 16));
+				char hex2 = Character.toUpperCase(Character.forDigit(b & 0xF, 16));
+				baos.write(hex1);
+				baos.write(hex2);
+			}
+		}
+		return fileScheme + copyToString(baos, charset);
+	}
+	
+	/**
+	 * Copy the contents of the given {@link ByteArrayOutputStream} into a
+	 * {@link String}.
+	 * <p>
+	 * This is a more effective equivalent of
+	 * {@code new String(baos.toByteArray(), charset)}.
+	 * 
+	 * @param baos    the {@code ByteArrayOutputStream} to be copied into a String
+	 * @param charset the {@link Charset} to use to decode the bytes
+	 * @return the String that has been copied to (possibly empty)
+	 */
+	private static String copyToString(ByteArrayOutputStream baos, Charset charset) {
+		try {
+			// Can be replaced with toString(Charset) call in Java 10+
+			return baos.toString(charset.name());
+		} catch (UnsupportedEncodingException ex) {
+			// Should never happen
+			throw new IllegalArgumentException("Invalid charset name: " + charset, ex);
+		}
+	}
+	
+	private static boolean isAllowed(int c) {
+		return isUnreserved(c) || '/' == c;
+	}
+
+	/**
+	 * Indicates whether the given character is in the {@code unreserved} set.
+	 * 
+	 * @see <a href="https://www.ietf.org/rfc/rfc3986.txt">RFC 3986, appendix A</a>
+	 */
+	private static boolean isUnreserved(int c) {
+		return (isAlpha(c) || isDigit(c) || '-' == c || '.' == c || '_' == c || '~' == c);
+	}
+
+	/**
+	 * Indicates whether the given character is in the {@code ALPHA} set.
+	 * 
+	 * @see <a href="https://www.ietf.org/rfc/rfc3986.txt">RFC 3986, appendix A</a>
+	 */
+	private static boolean isAlpha(int c) {
+		return (c >= 'a' && c <= 'z' || c >= 'A' && c <= 'Z');
+	}
+
+	/**
+	 * Indicates whether the given character is in the {@code DIGIT} set.
+	 * 
+	 * @see <a href="https://www.ietf.org/rfc/rfc3986.txt">RFC 3986, appendix A</a>
+	 */
+	private static boolean isDigit(int c) {
+		return (c >= '0' && c <= '9');
+	}
+}

--- a/lemminx-maven/src/test/java/org/eclipse/lemminx/extensions/maven/MavenLanguageService.java
+++ b/lemminx-maven/src/test/java/org/eclipse/lemminx/extensions/maven/MavenLanguageService.java
@@ -8,6 +8,11 @@
  *******************************************************************************/
 package org.eclipse.lemminx.extensions.maven;
 
+import java.util.HashMap;
+import java.util.Map;
+
+import org.eclipse.lemminx.dom.DOMDocument;
+import org.eclipse.lemminx.services.IXMLDocumentProvider;
 import org.eclipse.lemminx.services.XMLLanguageService;
 
 /**
@@ -18,8 +23,24 @@ import org.eclipse.lemminx.services.XMLLanguageService;
  */
 public class MavenLanguageService extends XMLLanguageService{
 	
+	private Map<String, DOMDocument> documents = new HashMap<>();
+	
 	public MavenLanguageService() {
 		MavenLemminxExtension.setUnitTestMode(true);
+		setDocumentProvider(new IXMLDocumentProvider() {
+			
+			@Override
+			public DOMDocument getDocument(String uri) {
+				return documents.get(uri);
+			}
+		});
 	}
-
+	
+	public void didOpen(DOMDocument document) {
+		// We need to store the dom document instance that test created because
+		// the dpcument content can changes in the test and when getDocument(String uri)
+		// will be called it need to use this instance otherwise it will get the 
+		// instance loaded from the file which have not changed
+		documents.put(document.getDocumentURI(), document);
+	}
 }

--- a/lemminx-maven/src/test/java/org/eclipse/lemminx/extensions/maven/MavenProjectCacheTest.java
+++ b/lemminx-maven/src/test/java/org/eclipse/lemminx/extensions/maven/MavenProjectCacheTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019-2022 Red Hat Inc. and others.
+ * Copyright (c) 2019-2023 Red Hat Inc. and others.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/
@@ -29,25 +29,37 @@ import org.apache.maven.project.MavenProject;
 import org.eclipse.lemminx.commons.TextDocument;
 import org.eclipse.lemminx.dom.DOMDocument;
 import org.eclipse.lemminx.extensions.contentmodel.settings.XMLValidationSettings;
-import org.eclipse.lemminx.services.XMLLanguageService;
 import org.eclipse.lemminx.services.extensions.IWorkspaceServiceParticipant;
 import org.eclipse.lsp4j.Diagnostic;
 import org.eclipse.lsp4j.DidChangeWorkspaceFoldersParams;
 import org.eclipse.lsp4j.WorkspaceFolder;
 import org.eclipse.lsp4j.WorkspaceFoldersChangeEvent;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 
 @ExtendWith(NoMavenCentralExtension.class)
 public class MavenProjectCacheTest {
-
+	private static MavenLanguageService languageService;
+	
+	@BeforeEach
+	public void setUp() {
+		MavenLemminxExtension.setUnitTestMode(true);
+		// Some tests require like a "cold: start with no any information cached
+		// So the language service is to be created at @BeforeEach
+		languageService = new MavenLanguageService();
+	}
+	
 	@Test
 	public void testSimpleProjectIsParsed() throws Exception {
+		MavenLemminxExtension plugin = new MavenLemminxExtension();
+		plugin.start(null,languageService);
+		
 		URI uri = getClass().getResource("/pom-with-properties.xml").toURI();
 		String content = Files.readString(new File(uri).toPath(), StandardCharsets.UTF_8);
 		DOMDocument doc = new DOMDocument(new TextDocument(content, uri.toString()), null);
-		MavenLemminxExtension plugin = new MavenLemminxExtension();
-		MavenLemminxExtension.setUnitTestMode(true);
+		languageService.didOpen(doc);
+
 		MavenProjectCache cache = plugin.getProjectCache();
 		MavenProject project = cache.getLastSuccessfulMavenProject(doc);
 		assertNotNull(project);
@@ -55,12 +67,15 @@ public class MavenProjectCacheTest {
 
 	@Test
 	public void testOnBuildError_ResolveProjectFromDocumentBytes() throws Exception {
+		MavenLemminxExtension plugin = new MavenLemminxExtension();
+		plugin.start(null,languageService);
+		
 		URI uri = getClass().getResource("/pom-with-module-error.xml").toURI();
 		File pomFile = new File(uri);
 		String content = Files.readString(pomFile.toPath(), StandardCharsets.UTF_8);
 		DOMDocument doc = new DOMDocument(new TextDocument(content, uri.toString()), null);
-		MavenLemminxExtension plugin = new MavenLemminxExtension();
-		MavenLemminxExtension.setUnitTestMode(true);
+		languageService.didOpen(doc);
+		
 		MavenProjectCache cache = plugin.getProjectCache();
 		MavenProject project = cache.getLastSuccessfulMavenProject(doc);
 		assertNotNull(project);
@@ -70,9 +85,12 @@ public class MavenProjectCacheTest {
 	public void testParentChangeReflectedToChild()
 			throws IOException, InterruptedException, ExecutionException, URISyntaxException, Exception {
 		MavenLemminxExtension plugin = new MavenLemminxExtension();
-		MavenLemminxExtension.setUnitTestMode(true);
+		plugin.start(null,languageService);
+
 		MavenProjectCache cache = plugin.getProjectCache();
-		DOMDocument doc = getDocument("/pom-with-properties-in-parent.xml");
+		DOMDocument doc = createDOMDocument("/pom-with-properties-in-parent.xml", languageService);
+		languageService.didOpen(doc);
+
 		MavenProject project = cache.getLastSuccessfulMavenProject(doc);
 		assertTrue(project.getProperties().containsKey("myProperty"), project.getProperties().toString());
 		URI parentUri = getClass().getResource("/pom-with-properties.xml").toURI();
@@ -92,7 +110,6 @@ public class MavenProjectCacheTest {
 
 	@Test
 	public void testAddFolders_didChangeWorkspaceFolders() throws Exception {
-		XMLLanguageService languageService = new MavenLanguageService();
 		IWorkspaceServiceParticipant workspaceService = languageService.getWorkspaceServiceParticipants().stream().filter(MavenWorkspaceService.class::isInstance).findAny().get();
 		assertNotNull(workspaceService);
 		
@@ -111,13 +128,14 @@ public class MavenProjectCacheTest {
 		// error messages should appear.
 		//
 		DOMDocument doc = createDOMDocument("/modules/dependent/module-c-pom.xml", languageService);
+		languageService.didOpen(doc);
+
 		List<Diagnostic> diagnostics = languageService.doDiagnostics(doc, new XMLValidationSettings(), Map.of(), () -> {});
 		assertFalse(diagnostics.stream().anyMatch(diag -> (diag.getMessage().contains("ModuleA"))));
 	}
 	
 //	@Test
 	public void testRemoveFolders_didChangeWorkspaceFolders() throws Exception {
-		XMLLanguageService languageService = new MavenLanguageService();
 		IWorkspaceServiceParticipant workspaceService = languageService.getWorkspaceServiceParticipants().stream().filter(MavenWorkspaceService.class::isInstance).findAny().get();
 		assertNotNull(workspaceService);
 		
@@ -143,6 +161,8 @@ public class MavenProjectCacheTest {
 		// error message should appear.
 		//
 		DOMDocument doc = createDOMDocument("/modules/dependent/module-c-pom.xml", languageService);
+		languageService.didOpen(doc);
+
 		List<Diagnostic> diagnostics = languageService.doDiagnostics(doc, new XMLValidationSettings(), Map.of(), () -> {});
 		assertTrue(diagnostics.stream().anyMatch(diag -> (diag.getMessage().contains("ModuleA"))));
 	}
@@ -151,9 +171,9 @@ public class MavenProjectCacheTest {
 	public void testNormilizePathsAreUsedInCache()
 			throws IOException, InterruptedException, ExecutionException, URISyntaxException, Exception {
 		MavenLemminxExtension plugin = new MavenLemminxExtension();
-		MavenLemminxExtension.setUnitTestMode(true);
+		plugin.start(null,languageService);
+
 		MavenProjectCache cache = plugin.getProjectCache();
-		
 		int initialProjectsSize = cache.getProjects().size();
 		
 		// Use URLretative to a child to access a parent pom.xml
@@ -219,14 +239,6 @@ public class MavenProjectCacheTest {
 		File pomFile = new File(baseDirectory, resource);
 		String content = Files.readString(pomFile.toPath(), StandardCharsets.UTF_8);
 		DOMDocument doc = new DOMDocument(new TextDocument(content, pomFile.toURI().toString()), null);
-		return doc;
-	}
-	
-	private DOMDocument getDocument(String resource) throws URISyntaxException, IOException {
-		URI uri = getClass().getResource(resource).toURI();
-		File pomFile = new File(uri);
-		String content = Files.readString(pomFile.toPath(), StandardCharsets.UTF_8);
-		DOMDocument doc = new DOMDocument(new TextDocument(content, uri.toString()), null);
 		return doc;
 	}
 }

--- a/lemminx-maven/src/test/java/org/eclipse/lemminx/extensions/maven/participants/SimpleModelTest.java
+++ b/lemminx-maven/src/test/java/org/eclipse/lemminx/extensions/maven/participants/SimpleModelTest.java
@@ -40,7 +40,6 @@ import org.eclipse.lemminx.extensions.maven.MavenWorkspaceService;
 import org.eclipse.lemminx.extensions.maven.NoMavenCentralExtension;
 import org.eclipse.lemminx.extensions.maven.utils.DOMUtils;
 import org.eclipse.lemminx.extensions.maven.utils.MavenLemminxTestsUtils;
-import org.eclipse.lemminx.services.XMLLanguageService;
 import org.eclipse.lemminx.services.extensions.IWorkspaceServiceParticipant;
 import org.eclipse.lemminx.settings.SharedSettings;
 import org.eclipse.lemminx.utils.XMLPositionUtility;
@@ -68,7 +67,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 @ExtendWith(NoMavenCentralExtension.class)
 public class SimpleModelTest {
 
-	private XMLLanguageService languageService;
+	private MavenLanguageService languageService;
 
 	@BeforeEach
 	public void setUp() throws IOException {
@@ -85,28 +84,35 @@ public class SimpleModelTest {
 	@Test
 	@Timeout(10000)
 	public void testScopeCompletion() throws IOException, InterruptedException, ExecutionException, URISyntaxException {
-		CompletionList completion = languageService.doComplete(createDOMDocument("/pom-with-module-error.xml", languageService),
+		DOMDocument document = createDOMDocument("/pom-with-module-error.xml", languageService);
+		languageService.didOpen(document);
+		
+		CompletionList completion = languageService.doComplete(document,
 				new Position(12, 10), new SharedSettings());
 		assertTrue(completion.getItems().stream().map(CompletionItem::getLabel).anyMatch("runtime"::equals));
 	}
-
 
 	@Test
 	@Timeout(10000)
 	public void testPropertyCompletion()
 			throws IOException, InterruptedException, ExecutionException, URISyntaxException {
-		CompletionList completion = languageService.doComplete(createDOMDocument("/pom-with-properties.xml", languageService),
+		DOMDocument document = createDOMDocument("/pom-with-properties.xml", languageService);
+		languageService.didOpen(document);
+
+		CompletionList completion = languageService.doComplete(document,
 				new Position(11, 15), new SharedSettings());
 		assertTrue(completion.getItems().stream().map(CompletionItem::getLabel).anyMatch(label -> label.contains("myProperty")));
 		assertTrue(completion.getItems().stream().map(CompletionItem::getLabel).anyMatch(label -> label.contains("project.build.directory")));
 	}
 
-
 	@Test
 	@Timeout(10000)
 	public void testParentPropertyCompletion()
 			throws IOException, InterruptedException, ExecutionException, URISyntaxException {
-		assertTrue(languageService.doComplete(createDOMDocument("/pom-with-properties-in-parent.xml", languageService), new Position(15, 20), new SharedSettings())
+		DOMDocument document = createDOMDocument("/pom-with-properties-in-parent.xml", languageService);
+		languageService.didOpen(document);
+
+		assertTrue(languageService.doComplete(document, new Position(15, 20), new SharedSettings())
 				.getItems().stream().map(CompletionItem::getLabel).anyMatch(label -> label.contains("myProperty")));
 	}
 
@@ -115,10 +121,17 @@ public class SimpleModelTest {
 	public void testLocalParentGAVCompletion()
 			throws IOException, InterruptedException, ExecutionException, URISyntaxException, TimeoutException {
 		// * if relativePath is set and resolve to a pom or a folder containing a pom, GAV must be available for completion
-		assertTrue(languageService.doComplete(createDOMDocument("/hierarchy/child/grandchild/pom.xml", languageService),
+		DOMDocument document = createDOMDocument("/hierarchy/child/grandchild/pom.xml", languageService);
+		languageService.didOpen(document);
+	
+		assertTrue(languageService.doComplete(document,
 				new Position(4, 2), new SharedSettings()).getItems().stream().map(CompletionItem::getLabel).anyMatch(label -> label.startsWith("test-parent")));
+
 		// * if relativePath is not set and parent contains a pom, complete GAV from parent
-		assertTrue(languageService.doComplete(createDOMDocument("/hierarchy/child/pom.xml", languageService),
+		document = createDOMDocument("/hierarchy/child/pom.xml", languageService);
+		languageService.didOpen(document);
+
+		assertTrue(languageService.doComplete(document,
 				new Position(4, 2), new SharedSettings()).getItems().stream().map(CompletionItem::getLabel).anyMatch(label -> label.startsWith("test-parent")));
 		// TODO:
 		// * if relativePath is not set, complete with local repo artifacts with "pom" packaging
@@ -130,6 +143,8 @@ public class SimpleModelTest {
 			throws IOException, InterruptedException, ExecutionException, URISyntaxException {
 		TextDocument textDocument = new TextDocument("<project> < </project>", "file:///pom.xml");
 		DOMDocument document = DOMParser.getInstance().parse(textDocument, languageService.getResolverExtensionManager());
+		languageService.didOpen(document);
+		
 		List<Diagnostic> diagnostics = languageService.doDiagnostics(document, new XMLValidationSettings(), Map.of(), () -> {});
 		assertFalse(diagnostics.stream().anyMatch(diag -> diag.getMessage().contains("Non-parseable POM")));
 	}
@@ -138,13 +153,19 @@ public class SimpleModelTest {
 	public void testMissingArtifactIdError()
 			throws IOException, InterruptedException, ExecutionException, URISyntaxException {
 		DOMDocument document = createDOMDocument("/pom-without-artifactId.xml", languageService);
-		assertTrue(languageService.doDiagnostics(document, new XMLValidationSettings(), Map.of(), () -> {}).stream().map(Diagnostic::getMessage)
+		languageService.didOpen(document);
+
+		List<Diagnostic>diagnostics = languageService.doDiagnostics(document, new XMLValidationSettings(), Map.of(), () -> {});
+		System.out.println(diagnostics);
+		assertTrue(diagnostics.stream().map(Diagnostic::getMessage)
 				.anyMatch(message -> message.contains("artifactId")));
 		// simulate an edit
 		TextDocument textDocument = document.getTextDocument();
 		textDocument.setText(textDocument.getText().replace("</project>", "<artifactId>a</artifactId></project>"));
 		textDocument.setVersion(textDocument.getVersion() + 1);
 		document = DOMParser.getInstance().parse(textDocument, languageService.getResolverExtensionManager());
+		languageService.didOpen(document);
+		
 		assertEquals(Collections.emptyList(), languageService.doDiagnostics(document, new XMLValidationSettings(), Map.of(), () -> {}));
 	}
 
@@ -152,6 +173,8 @@ public class SimpleModelTest {
 	public void testSystemPathDiagnosticBug()
 			throws IOException, InterruptedException, ExecutionException, URISyntaxException {
 		DOMDocument document = createDOMDocument("/pom-environment-variable-property.xml", languageService);
+		languageService.didOpen(document);
+		
 		List<Diagnostic> diagnostics = languageService.doDiagnostics(document, new XMLValidationSettings(), Map.of(), () -> {});
 		assertFalse(diagnostics.stream().anyMatch(diag -> diag.getMessage().contains("${env")));
 	}
@@ -159,7 +182,10 @@ public class SimpleModelTest {
 	@Test
 	public void testEnvironmentVariablePropertyHover()
 			throws IOException, InterruptedException, ExecutionException, URISyntaxException {
-		String hoverContents = languageService.doHover(createDOMDocument("/pom-environment-variable-property.xml", languageService),
+		DOMDocument document = createDOMDocument("/pom-environment-variable-property.xml", languageService);
+		languageService.didOpen(document);
+		
+		String hoverContents = languageService.doHover(document,
 				new Position(16, 18), new SharedSettings()).getContents().getRight().getValue();
 		// We can't test the value of an environment variable as it is platform-dependent
 		assertNotNull(hoverContents);
@@ -169,6 +195,8 @@ public class SimpleModelTest {
 	public void testCompletionEnvironmentVariableProperty()
 			throws IOException, InterruptedException, ExecutionException, URISyntaxException {
 		DOMDocument document = createDOMDocument("/pom-environment-variable-property.xml", languageService);
+		languageService.didOpen(document);
+		
 		List<CompletionItem> completions = languageService.doComplete(document, new Position(16, 49), new SharedSettings()).getItems();
 		assertTrue(completions.stream().map(CompletionItem::getTextEdit).map(Either::getLeft).map(TextEdit::getNewText)
 				.anyMatch("${env.PATH}"::equals));
@@ -178,6 +206,8 @@ public class SimpleModelTest {
 	@Timeout(15000)
 	public void testCompleteScope() throws IOException, InterruptedException, ExecutionException, URISyntaxException {
 		DOMDocument document = createDOMDocument("/pom-scope.xml", languageService);
+		languageService.didOpen(document);
+		
 		assertTrue(languageService.doComplete(document, new Position(0, 7), new SharedSettings()).getItems().stream().map(CompletionItem::getTextEdit).map(Either::getLeft).map(TextEdit::getNewText)
 				.anyMatch("compile"::equals));
 		assertTrue(languageService.doComplete(document, new Position(1, 7), new SharedSettings()).getItems().stream().map(CompletionItem::getTextEdit).map(Either::getLeft).map(TextEdit::getNewText)
@@ -188,6 +218,8 @@ public class SimpleModelTest {
 	@Timeout(15000)
 	public void testCompletePhase() throws IOException, InterruptedException, ExecutionException, URISyntaxException {
 		DOMDocument document = createDOMDocument("/pom-phase.xml", languageService);
+		languageService.didOpen(document);
+		
 		assertTrue(languageService.doComplete(document, new Position(0, 7), new SharedSettings()).getItems().stream().map(CompletionItem::getTextEdit).map(Either::getLeft).map(TextEdit::getNewText)
 				.anyMatch("generate-resources"::equals));
 		assertTrue(languageService.doComplete(document, new Position(1, 7), new SharedSettings()).getItems().stream().map(CompletionItem::getTextEdit).map(Either::getLeft).map(TextEdit::getNewText)
@@ -197,6 +229,8 @@ public class SimpleModelTest {
 	@Test
  	public void testPropertyHover() throws IOException, InterruptedException, ExecutionException, URISyntaxException {
 		DOMDocument document = createDOMDocument("/pom-with-properties.xml", languageService);
+		languageService.didOpen(document);
+		
 		Hover hover = languageService.doHover(document, new Position(15, 20), new SharedSettings());
  		assertTrue((((MarkupContent) hover.getContents().getRight()).getValue().contains("$")));
 
@@ -210,6 +244,8 @@ public class SimpleModelTest {
 	@Test
  	public void testPropertyDefinitionSameDocument() throws IOException, InterruptedException, ExecutionException, URISyntaxException {
 		DOMDocument document = createDOMDocument("/pom-with-properties-for-definition.xml", languageService);
+		languageService.didOpen(document);
+		
 		Position pos = new Position(14, 22);
 		List<? extends LocationLink> definitionLinks = languageService.findDefinition(document, pos, () -> {
 		});
@@ -225,6 +261,8 @@ public class SimpleModelTest {
 	@Test
  	public void testMultiplePropertyHover() throws IOException, InterruptedException, ExecutionException, URISyntaxException {
 		DOMDocument document = createDOMDocument("/pom-with-multiple-properties.xml", languageService);
+		languageService.didOpen(document);
+		
 		Position pos = new Position(16, 12);
 		Hover hover = languageService.doHover(document,pos, new SharedSettings());
 		Range firstHoverRange = hover.getRange();
@@ -241,6 +279,8 @@ public class SimpleModelTest {
 	public void testMultiplePropertyDefinitionRangeSameTag()
 			throws IOException, InterruptedException, ExecutionException, URISyntaxException {
 		DOMDocument document = createDOMDocument("/pom-with-multiple-properties.xml", languageService);
+		languageService.didOpen(document);
+		
 		Position pos = new Position(16, 12);
 		List<? extends LocationLink> definitionLinks = languageService.findDefinition(document, pos, () -> {
 		});
@@ -267,6 +307,8 @@ public class SimpleModelTest {
 	@Test
  	public void testPropertyDefinitionSameDocumentBug() throws IOException, InterruptedException, ExecutionException, URISyntaxException {
 		DOMDocument document = createDOMDocument("/pom-definition-wrong-tag-bug.xml", languageService);
+		languageService.didOpen(document);
+		
 		Position pos = new Position(22, 40);
 		List<? extends LocationLink> definitionLinks = languageService.findDefinition(document, pos, () -> {
 		});
@@ -284,12 +326,16 @@ public class SimpleModelTest {
 	@Test
  	public void testPropertyDefinitionParentDocument() throws IOException, InterruptedException, ExecutionException, URISyntaxException {
 		DOMDocument document = createDOMDocument("/pom-with-properties-in-parent-for-definition.xml", languageService);
+		languageService.didOpen(document);
+		
 		Position pos = new Position(23, 16);
 		List<? extends LocationLink> definitionLinks = languageService.findDefinition(document, pos, () -> {
 		});
 
 		//Verify the LocationLink points to the right file and node
 		DOMDocument targetDocument = createDOMDocument("/pom-with-properties-for-definition.xml", languageService);
+		languageService.didOpen(document);
+		
 		DOMNode propertyNode = DOMUtils.findNodesByLocalName(targetDocument, "myProperty").stream().filter(node -> node.getParentElement().getLocalName().equals("properties")).collect(Collectors.toList()).get(0);;
 		Range expectedTargetRange = XMLPositionUtility.createRange(propertyNode);
 		assertTrue(definitionLinks.stream().anyMatch(link -> link.getTargetUri().equals(targetDocument.getDocumentURI())));
@@ -300,43 +346,43 @@ public class SimpleModelTest {
 	@Test
 	public void testModuleDefinition() throws IOException, URISyntaxException {
 		DOMDocument document = createDOMDocument("/pom-module-definition.xml", languageService);
+		languageService.didOpen(document);
+		
 		Position pos = new Position(11, 5);
 		List<? extends LocationLink> definitionLinks = languageService.findDefinition(document, pos, () -> {
 		});
 
 		DOMDocument targetDocument = createDOMDocument("/multi-module/pom.xml", languageService);
+		languageService.didOpen(document);
+		
 		assertTrue(definitionLinks.stream().anyMatch(link -> link.getTargetUri().equals(targetDocument.getDocumentURI())));
 	}
 
 	@Test
 	public void testModules() throws IOException, URISyntaxException {
+		DOMDocument documentA = createDOMDocument("/modules/module-a-pom.xml", languageService);
+		languageService.didOpen(documentA);
+		
 		List<Diagnostic> diagnosticsA = languageService.doDiagnostics(
-				createDOMDocument("/modules/module-a-pom.xml", languageService), new XMLValidationSettings(), Map.of(),
-				() -> {
-				});
+				documentA, new XMLValidationSettings(), Map.of(), () -> {});
 		assertFalse(diagnosticsA.stream()
 				.anyMatch(diag -> (diag.getMessage().contains("ModuleA") || diag.getMessage().contains("ModuleB"))));
 
-		DOMDocument document = createDOMDocument("/modules/dependent/module-b-pom.xml", languageService);
-		List<Diagnostic> diagnosticsB = languageService.doDiagnostics(document, new XMLValidationSettings(), Map.of(),
-				() -> {
-				});
+		DOMDocument documentB = createDOMDocument("/modules/dependent/module-b-pom.xml", languageService);
+		languageService.didOpen(documentB);
+		
+		List<Diagnostic> diagnosticsB = languageService.doDiagnostics(
+				documentB, new XMLValidationSettings(), Map.of(), () -> {});
 		// As there is not workspace folders initialized, there is the error
 		// "Could not find artifact org.test.modules:ModuleA:jar:0.0.1-SNAPSHOT
 		assertArrayEquals(new Diagnostic[] { d(9, 4, 13, 17, null,
 				"", "xml", DiagnosticSeverity.Error), //
-		}, diagnosticsB
-				.stream()
-				.filter(d -> {
-					d.setMessage("");
-					return true;
-				})
-				.toList()
-				.toArray(new Diagnostic[diagnosticsB.size()]));
+		}, diagnosticsB.stream().filter(d -> {d.setMessage("");	return true;})
+				.toList().toArray(new Diagnostic[diagnosticsB.size()]));
 	}
 	
 	@Test
-	public void testModulesCompletionInDependency() throws IOException, URISyntaxException {
+	public void testModulesCompletionInDependency() throws IOException, URISyntaxException, InterruptedException {
 		// We need the WORKSPACE projects to be placed to MavenProjectCache
 		IWorkspaceServiceParticipant workspaceService = languageService.getWorkspaceServiceParticipants().stream().filter(MavenWorkspaceService.class::isInstance).findAny().get();
 		assertNotNull(workspaceService);
@@ -351,36 +397,65 @@ public class SimpleModelTest {
 								Arrays.asList(new WorkspaceFolder[] {wsFolder}), 
 								Arrays.asList(new WorkspaceFolder[0]))));
 		
+		DOMDocument documentA = createDOMDocument("/modules/module-a-pom.xml", languageService);
+		languageService.didOpen(documentA);
+		
 		List<Diagnostic> diagnosticsA = languageService.doDiagnostics(
-				createDOMDocument("/modules/module-a-pom.xml", languageService), 
-				new XMLValidationSettings(), Map.of(), () -> {});
+				documentA, new XMLValidationSettings(), Map.of(), () -> {});
 		assertFalse(diagnosticsA.stream().anyMatch(diag -> (diag.getMessage().contains("ModuleA") || diag.getMessage().contains("ModuleB"))));
 
-		DOMDocument document = createDOMDocument("/modules/dependent/module-b-pom.xml", languageService);
+		DOMDocument documentB = createDOMDocument("/modules/dependent/module-b-pom.xml", languageService);
+		languageService.didOpen(documentB);
+		
 		List<Diagnostic> diagnosticsB = languageService.doDiagnostics(
-				document, 
-				new XMLValidationSettings(), Map.of(), () -> {});
+				documentB, new XMLValidationSettings(), Map.of(), () -> {});
 		assertFalse(diagnosticsB.stream().anyMatch(diag -> (diag.getMessage().contains("ModuleA") || diag.getMessage().contains("ModuleB"))));
 
+		// The items collected from Workspace as well as from Maven Search API cannot be 
+		// immediately obtained due to the "lazy: loading, so, we need to wait until all 
+		// the required data  received and ready for use
+		
 		// in <dependency />
 		// for group ID
-		List<CompletionItem> completions = languageService.doComplete(document, new Position(10, 15), new SharedSettings()).getItems();
-		assertTrue(completions.stream().map(CompletionItem::getTextEdit).map(Either::getLeft).map(TextEdit::getNewText)
-				.anyMatch("org.test.modules"::equals));
-
+		List<CompletionItem> completions = null;
+		int triesLeft = 15; // given a 1-second `sleep` between the retries this gives >15 seconds overall timeout
+		boolean conditionMet = false;
+		do {
+			completions = languageService.doComplete(
+					documentB, new Position(10, 15), new SharedSettings())
+ 				.getItems();
+			Thread.sleep(1000);
+			conditionMet = completions.stream().map(CompletionItem::getTextEdit).map(Either::getLeft).map(TextEdit::getNewText)
+					.anyMatch("org.test.modules"::equals);
+		} while (!conditionMet && triesLeft-- > 0);
+		
 		// for artifact ID:
-		completions = languageService.doComplete(document, new Position(11, 18), new SharedSettings()).getItems();
-		assertTrue(completions.stream().map(CompletionItem::getTextEdit).map(Either::getLeft).map(TextEdit::getNewText)
-				.anyMatch("ModuleA"::equals));
+		triesLeft = 15; // given a 1-second `sleep` between the retries this gives >15 seconds overall timeout
+		conditionMet = false;
+		do {
+			completions = languageService.doComplete(
+					documentB, new Position(11, 18), new SharedSettings())
+ 				.getItems();
+			Thread.sleep(1000);
+			conditionMet = completions.stream().map(CompletionItem::getTextEdit).map(Either::getLeft).map(TextEdit::getNewText)
+					.anyMatch("ModuleA"::equals);
+		} while (!conditionMet && triesLeft-- > 0);
 
 		// for versions
-		completions = languageService.doComplete(document, new Position(12, 15), new SharedSettings()).getItems();
-		assertTrue(completions.stream().map(CompletionItem::getTextEdit).map(Either::getLeft).map(TextEdit::getNewText)
-				.anyMatch("0.0.1-SNAPSHOT"::equals));
+		triesLeft = 15; // given a 1-second `sleep` between the retries this gives >15 seconds overall timeout
+		conditionMet = false;
+		do {
+			completions = languageService.doComplete(
+					documentB, new Position(12, 15), new SharedSettings())
+ 				.getItems();
+			Thread.sleep(1000);
+			conditionMet = completions.stream().map(CompletionItem::getTextEdit).map(Either::getLeft).map(TextEdit::getNewText)
+					.anyMatch("0.0.1-SNAPSHOT"::equals);
+		} while (!conditionMet && triesLeft-- > 0);
 	}
 
 	@Test
-	public void testModulesCompletionInParent() throws IOException, URISyntaxException {
+	public void testModulesCompletionInParent() throws IOException, URISyntaxException, InterruptedException {
 		// We need the WORKSPACE projects to be placed to MavenProjectCache
 		IWorkspaceServiceParticipant workspaceService = languageService.getWorkspaceServiceParticipants().stream().filter(MavenWorkspaceService.class::isInstance).findAny().get();
 		assertNotNull(workspaceService);
@@ -395,32 +470,57 @@ public class SimpleModelTest {
 								Arrays.asList(new WorkspaceFolder[] {wsFolder}), 
 								Arrays.asList(new WorkspaceFolder[0]))));
 
+		DOMDocument documentA = createDOMDocument("/modules/module-a-pom.xml", languageService);
+		languageService.didOpen(documentA);
+
 		List<Diagnostic> diagnosticsA = languageService.doDiagnostics(
-				createDOMDocument("/modules/module-a-pom.xml", languageService), 
-				new XMLValidationSettings(), Map.of(), () -> {});
+				documentA, new XMLValidationSettings(), Map.of(), () -> {});
 		assertFalse(diagnosticsA.stream().anyMatch(diag -> (diag.getMessage().contains("ModuleA") || diag.getMessage().contains("ModuleB"))));
 
-		DOMDocument document = createDOMDocument("/modules/dependent/module-c-pom.xml", languageService);
+		DOMDocument documentC = createDOMDocument("/modules/dependent/module-c-pom.xml", languageService);
+		languageService.didOpen(documentC);
+
 		List<Diagnostic> diagnosticsC = languageService.doDiagnostics(
-				document, 
-				new XMLValidationSettings(), Map.of(), () -> {});
+				documentC, new XMLValidationSettings(), Map.of(), () -> {});
 		assertFalse(diagnosticsC.stream().anyMatch(diag -> (diag.getMessage().contains("ModuleA") || diag.getMessage().contains("ModuleB"))));
 
 		// in <parent />
 		// for group ID
-		List<CompletionItem> completions = languageService.doComplete(document, new Position(9, 13), new SharedSettings()).getItems();
-		assertTrue(completions.stream().map(CompletionItem::getTextEdit).map(Either::getLeft).map(TextEdit::getNewText)
-				.anyMatch("org.test.modules"::equals));
-
+		List<CompletionItem> completions = null;
+		int triesLeft = 15; // given a 1-second `sleep` between the retries this gives >15 seconds overall timeout
+		boolean conditionMet = false;
+		do {
+			completions = languageService.doComplete(
+					documentC, new Position(9, 13), new SharedSettings())
+ 				.getItems();
+			Thread.sleep(1000);
+			conditionMet = completions.stream().map(CompletionItem::getTextEdit).map(Either::getLeft).map(TextEdit::getNewText)
+					.anyMatch("org.test.modules"::equals);
+		} while (!conditionMet && triesLeft-- > 0);
+		
 		// for artifact ID:
-		completions = languageService.doComplete(document, new Position(10, 16), new SharedSettings()).getItems();
-		assertTrue(completions.stream().map(CompletionItem::getTextEdit).map(Either::getLeft).map(TextEdit::getNewText)
-				.anyMatch("ModuleA"::equals));
+		triesLeft = 15; // given a 1-second `sleep` between the retries this gives >15 seconds overall timeout
+		conditionMet = false;
+		do {
+			completions = languageService.doComplete(
+					documentC,  new Position(10, 16), new SharedSettings())
+ 				.getItems();
+			Thread.sleep(1000);
+			conditionMet = completions.stream().map(CompletionItem::getTextEdit).map(Either::getLeft).map(TextEdit::getNewText)
+					.anyMatch("ModuleA"::equals);
+		} while (!conditionMet && triesLeft-- > 0);
 
 		// for versions
-		completions = languageService.doComplete(document, new Position(11, 13), new SharedSettings()).getItems();
-		assertTrue(completions.stream().map(CompletionItem::getTextEdit).map(Either::getLeft).map(TextEdit::getNewText)
-				.anyMatch("0.0.1-SNAPSHOT"::equals));
+		triesLeft = 15; // given a 1-second `sleep` between the retries this gives >15 seconds overall timeout
+		conditionMet = false;
+		do {
+			completions = languageService.doComplete(
+					documentC, new Position(11, 13), new SharedSettings())
+ 				.getItems();
+			Thread.sleep(1000);
+			conditionMet = completions.stream().map(CompletionItem::getTextEdit).map(Either::getLeft).map(TextEdit::getNewText)
+					.anyMatch("0.0.1-SNAPSHOT"::equals);
+		} while (!conditionMet && triesLeft-- > 0);
 	}
 	
 	@Test
@@ -440,12 +540,16 @@ public class SimpleModelTest {
 								Arrays.asList(new WorkspaceFolder[0]))));
 
 		DOMDocument document = createDOMDocument("/modules/dependent/module-b-pom.xml", languageService);
+		languageService.didOpen(document);
+
 		Position pos = new Position(11, 18);
 		List<? extends LocationLink> definitionLinks = languageService.findDefinition(document, pos, () -> {
 		});
 		assertFalse(definitionLinks.isEmpty());
 
 		DOMDocument targetDocument = createDOMDocument("/modules/module-a-pom.xml", languageService);
+		languageService.didOpen(targetDocument);
+
 		assertTrue(definitionLinks.stream().anyMatch(link -> link.getTargetUri().equals(targetDocument.getDocumentURI())));
 	}
 
@@ -466,12 +570,16 @@ public class SimpleModelTest {
 								Arrays.asList(new WorkspaceFolder[0]))));
 
 		DOMDocument document = createDOMDocument("/modules/dependent/module-c-pom.xml", languageService);
+		languageService.didOpen(document);
+
 		Position pos = new Position(10, 16);
 		List<? extends LocationLink> definitionLinks = languageService.findDefinition(document, pos, () -> {
 		});
 		assertFalse(definitionLinks.isEmpty());
 
 		DOMDocument targetDocument = createDOMDocument("/modules/module-a-pom.xml", languageService);
+		languageService.didOpen(targetDocument);
+
 		assertTrue(definitionLinks.stream().anyMatch(link -> link.getTargetUri().equals(targetDocument.getDocumentURI())));
 	}
 
@@ -491,6 +599,8 @@ public class SimpleModelTest {
 								Arrays.asList(new WorkspaceFolder[0]))));
 
 		DOMDocument document = createDOMDocument("/modules/dependent/module-b-pom.xml", languageService);
+		languageService.didOpen(document);
+
 		
 		// Hover over groupID text
 		Position pos = new Position(10, 16);	// <groupId>o|rg.test.modules</groupId>
@@ -524,7 +634,8 @@ public class SimpleModelTest {
 								Arrays.asList(new WorkspaceFolder[0]))));
 
 		DOMDocument document = createDOMDocument("/modules/dependent/module-c-pom.xml", languageService);
-		
+		languageService.didOpen(document);
+
 		// Hover over groupID text
 		Position pos = new Position(9, 14);	// <groupId>o|rg.test.modules</groupId>
 		Hover hover = languageService.doHover(document, pos, new SharedSettings());
@@ -544,34 +655,46 @@ public class SimpleModelTest {
 	@Test
 	public void testParentDefinitionWithRelativePath() throws IOException, URISyntaxException {
 		DOMDocument document = createDOMDocument("/pom-with-properties-in-parent-for-definition.xml", languageService);
+		languageService.didOpen(document);
+
 		Position pos = new Position(6, 9);
 		List<? extends LocationLink> definitionLinks = languageService.findDefinition(document, pos, () -> {
 		});
 
 		DOMDocument targetDocument = createDOMDocument("/pom-with-properties-for-definition.xml", languageService);
+		languageService.didOpen(targetDocument);
+
 		assertTrue(definitionLinks.stream().anyMatch(link -> link.getTargetUri().equals(targetDocument.getDocumentURI())));
 	}
 
 	@Test
 	public void testParentDefinitionWithoutRelativePath() throws IOException, URISyntaxException {
 		DOMDocument document = createDOMDocument("/multi-module/folder1/pom.xml", languageService);
+		languageService.didOpen(document);
+
 		Position pos = new Position(6, 9);
 		List<? extends LocationLink> definitionLinks = languageService.findDefinition(document, pos, () -> {
 		});
 
 		DOMDocument targetDocument = createDOMDocument("/multi-module/pom.xml", languageService);
+		languageService.didOpen(targetDocument);
+
 		assertTrue(definitionLinks.stream().anyMatch(link -> link.getTargetUri().equals(targetDocument.getDocumentURI())));
 	}
 
 	@Test
 	public void testBOMDependency() throws IOException, URISyntaxException {
 		DOMDocument document = createDOMDocument("/pom-bom.xml", languageService);
+		languageService.didOpen(document);
+
 		assertEquals(Collections.emptyList(), languageService.doDiagnostics(document, new XMLValidationSettings(), Map.of(), () -> {}));
 	}
 
 	@Test
 	public void testCompleteSNAPSHOT() throws Exception {
 		DOMDocument document = createDOMDocument("/pom-version.xml", languageService);
+		languageService.didOpen(document);
+		
 		Optional<TextEdit> edit = languageService.doComplete(document, new Position(0, 11), new SharedSettings()).getItems().stream().map(CompletionItem::getTextEdit).map(Either::getLeft).findFirst();
 		assertTrue(edit.isPresent());
 		assertEquals("-SNAPSHOT", edit.get().getNewText());
@@ -581,6 +704,8 @@ public class SimpleModelTest {
 	@Test
 	public void testResolveParentFromCentralWhenAnotherRepoIsDeclared() throws Exception {
 		DOMDocument document = createDOMDocument("/it1/pom.xml", languageService);
+		languageService.didOpen(document);
+		
 		assertArrayEquals(new Diagnostic[] { //
 				// org.sonatype.forge:forge-parent:jar:10 failed to transfer from https://download.eclipse.org/eclipse/updates/4.16/ 
 				// during a previous attempt. This failure was cached in the local repository and resolution is not reattempted 
@@ -591,8 +716,8 @@ public class SimpleModelTest {
 				// during a previous attempt. This failure was cached in the local repository and resolution is 
 				// not reattempted until the update interval of central has elapsed or updates are forced
 				d(27, 0, 31, 13, null,	"", "xml", DiagnosticSeverity.Error) //
-				}
-		, languageService.doDiagnostics(document, new XMLValidationSettings(), Map.of(), () -> {})
+				},
+		languageService.doDiagnostics(document, new XMLValidationSettings(), Map.of(), () -> {})
 			.stream()
 			.filter(diag -> {
 				// as message is to complex, we don't compare them
@@ -601,18 +726,14 @@ public class SimpleModelTest {
 			})
 			.toArray(Diagnostic[]::new));
 	}
-	
-	
 
 	@Test
 	public void testSystemPath() throws Exception {
-		// We create an instance here of language service to be sure that workspace
-		// folders will be not filled by an another test
-		MavenLanguageService languageService = new MavenLanguageService();
+		DOMDocument document = createDOMDocument("/pom-systemPath.xml", languageService);
+		languageService.didOpen(document);
+
 		List<Diagnostic> diagnostics = languageService.doDiagnostics(
-				createDOMDocument("/pom-systemPath.xml", languageService), new XMLValidationSettings(), Map.of(),
-				() -> {
-				});
+				document, new XMLValidationSettings(), Map.of(), () -> {});
 		// 'dependencies.dependency.systemPath' for a:a:jar should not point at files
 		// within the project directory, ${basedir} will be unresolvable by dependent
 		// projects
@@ -627,6 +748,8 @@ public class SimpleModelTest {
 	@Test
 	public void testPluginInProfileOnly() throws Exception {
 		DOMDocument document = createDOMDocument("/pom-gpg.xml", languageService);
+		languageService.didOpen(document);
+
 		Optional<Diagnostic> diagnostics = languageService.doDiagnostics(
 				document, new XMLValidationSettings(), Map.of(), () -> {}).stream().filter(diag -> diag.getSeverity() == DiagnosticSeverity.Warning).findAny();
 		assertTrue(diagnostics.isEmpty(), () -> diagnostics.map(Object::toString).get());
@@ -640,7 +763,10 @@ public class SimpleModelTest {
 				new WorkspaceFolder(MavenLemminxTestsUtils.class.getResource(childFolder).toURI().toString()),
 				new WorkspaceFolder(MavenLemminxTestsUtils.class.getResource("/parentAsSiblingProjectWithoutRelativePath/parent").toURI().toString())));
 		languageService.initializeParams(params);
+
 		DOMDocument document = createDOMDocument(childFolder + "/pom.xml", languageService);
+		languageService.didOpen(document);
+
 		Optional<Diagnostic> diagnostics = languageService.doDiagnostics(
 				document, new XMLValidationSettings(), Map.of(), () -> {}).stream().findAny();
 		assertTrue(diagnostics.isEmpty(), () -> diagnostics.map(Object::toString).get());

--- a/lemminx-maven/src/test/java/org/eclipse/lemminx/extensions/maven/participants/rename/MavenPropertyRenameParticipantTest.java
+++ b/lemminx-maven/src/test/java/org/eclipse/lemminx/extensions/maven/participants/rename/MavenPropertyRenameParticipantTest.java
@@ -31,7 +31,6 @@ import org.eclipse.lemminx.extensions.maven.MavenLanguageService;
 import org.eclipse.lemminx.extensions.maven.MavenWorkspaceService;
 import org.eclipse.lemminx.extensions.maven.NoMavenCentralExtension;
 import org.eclipse.lemminx.extensions.maven.utils.DOMUtils;
-import org.eclipse.lemminx.services.XMLLanguageService;
 import org.eclipse.lemminx.services.extensions.IWorkspaceServiceParticipant;
 import org.eclipse.lsp4j.DidChangeWorkspaceFoldersParams;
 import org.eclipse.lsp4j.Position;
@@ -47,14 +46,15 @@ import org.junit.jupiter.api.extension.ExtendWith;
 
 @ExtendWith(NoMavenCentralExtension.class)
 public class MavenPropertyRenameParticipantTest {
-	private XMLLanguageService xmlLanguageService = new MavenLanguageService();
+	private MavenLanguageService languageService = new MavenLanguageService();
 
 	@Test
 	public void testRenameMavenProperty() throws Exception {
 		String propertyName = "myPropertyGroupId"; 
 		String newPropertyName = "new-group-id"; 
-		DOMDocument xmlDocument = createDOMDocument("/property-refactoring/pom-with-property.xml", xmlLanguageService);
-
+		DOMDocument xmlDocument = createDOMDocument("/property-refactoring/pom-with-property.xml", languageService);
+		languageService.didOpen(xmlDocument);
+		
 		Optional<DOMElement> properties = DOMUtils.findChildElement(xmlDocument.getDocumentElement(), PROPERTIES_ELT);
 		assertTrue(properties.isPresent(), "'<properties>'  Element doesn't exist!");
 
@@ -93,14 +93,14 @@ public class MavenPropertyRenameParticipantTest {
 		Position startTagMiddle = xmlDocument.positionAt((startTagOpenOffset + startTagCloseOffset) / 2);
 
 		Either<Range, PrepareRenameResult> prepareResult = 
-				xmlLanguageService.prepareRename(xmlDocument, startTagMiddle, () -> {});
+				languageService.prepareRename(xmlDocument, startTagMiddle, () -> {});
 		assertNotNull(prepareResult, "Prepare Result is null!");
 		assertNotNull(prepareResult.getLeft(), "Prepare Result Range is null!");
 
 		Range prepareResultRange = prepareResult.getLeft();
 		assertEquals(expectedStartTagRange, prepareResultRange);
 
-		WorkspaceEdit renameReult = xmlLanguageService.doRename(xmlDocument, startTagMiddle, newPropertyName, () -> {});
+		WorkspaceEdit renameReult = languageService.doRename(xmlDocument, startTagMiddle, newPropertyName, () -> {});
 		assertNotNull(renameReult, "Prepare Result is null!");
 		assertNotNull(renameReult.getDocumentChanges(), "Rename result document changes is null!");
 		assertEquals(expectedRenameResult, renameReult);
@@ -108,14 +108,14 @@ public class MavenPropertyRenameParticipantTest {
 		// Test renaming end tag of maven property definition
 		Position endTagMiddle = xmlDocument.positionAt((endTagOpenOffset + endTagCloseOffset) / 2);
 
-		prepareResult = xmlLanguageService.prepareRename(xmlDocument, endTagMiddle, () -> {});
+		prepareResult = languageService.prepareRename(xmlDocument, endTagMiddle, () -> {});
 		assertNotNull(prepareResult, "Prepare Result is null!");
 		assertNotNull(prepareResult.getLeft(), "Prepare Result Range is null!");
 
 		prepareResultRange = prepareResult.getLeft();
 		assertEquals(expectedEndTagRange, prepareResultRange);
 
-		renameReult = xmlLanguageService.doRename(xmlDocument, endTagMiddle, newPropertyName, () -> {});
+		renameReult = languageService.doRename(xmlDocument, endTagMiddle, newPropertyName, () -> {});
 		assertNotNull(renameReult, "Prepare Result is null!");
 		assertNotNull(renameReult.getDocumentChanges(), "Rename result document changes is null!");
 		assertEquals(expectedRenameResult, renameReult);
@@ -126,14 +126,14 @@ public class MavenPropertyRenameParticipantTest {
 				(firstUse.getStart().getLine() + firstUse.getEnd().getLine()) / 2,
 				(firstUse.getStart().getCharacter() + firstUse.getEnd().getCharacter()) / 2);				
 
-		prepareResult = xmlLanguageService.prepareRename(xmlDocument, firstUseMiddle, () -> {});
+		prepareResult = languageService.prepareRename(xmlDocument, firstUseMiddle, () -> {});
 		assertNotNull(prepareResult, "Prepare Result is null!");
 		assertNotNull(prepareResult.getLeft(), "Prepare Result Range is null!");
 
 		prepareResultRange = prepareResult.getLeft();
 		assertEquals(expectedFirstUseRange, prepareResultRange);
 
-		renameReult = xmlLanguageService.doRename(xmlDocument, firstUseMiddle, newPropertyName, () -> {});
+		renameReult = languageService.doRename(xmlDocument, firstUseMiddle, newPropertyName, () -> {});
 		assertNotNull(renameReult, "Prepare Result is null!");
 		assertNotNull(renameReult.getDocumentChanges(), "Rename result document changes is null!");
 		assertEquals(expectedRenameResult, renameReult);
@@ -142,7 +142,7 @@ public class MavenPropertyRenameParticipantTest {
 	@Test
 	public void testRenameMavenPropertyWithChildren() throws Exception {
 		// We need the WORKSPACE projects to be placed to MavenProjectCache
-		IWorkspaceServiceParticipant workspaceService = xmlLanguageService.getWorkspaceServiceParticipants().stream().filter(MavenWorkspaceService.class::isInstance).findAny().get();
+		IWorkspaceServiceParticipant workspaceService = languageService.getWorkspaceServiceParticipants().stream().filter(MavenWorkspaceService.class::isInstance).findAny().get();
 		assertNotNull(workspaceService);
 
 		URI folderUri = getClass().getResource("/property-refactoring/child").toURI();
@@ -157,7 +157,9 @@ public class MavenPropertyRenameParticipantTest {
 
 		String propertyName = "test-version";
 		String newPropertyName = "new-test-version"; 
-		DOMDocument xmlDocument = createDOMDocument("/property-refactoring/child/parent/pom.xml", xmlLanguageService);
+		DOMDocument xmlDocument = createDOMDocument("/property-refactoring/child/parent/pom.xml", languageService);
+		languageService.didOpen(xmlDocument);
+
 		assertNotNull(xmlDocument, "Parent document not found!");
 
 		Optional<DOMElement> properties = DOMUtils.findChildElement(xmlDocument.getDocumentElement(), PROPERTIES_ELT);
@@ -183,7 +185,9 @@ public class MavenPropertyRenameParticipantTest {
 		Range expectedFirstUseRange = propertyUseRanges.get(0);
 
 		// Save property use ranges for child document
-		DOMDocument childXmlDocument = createDOMDocument("/property-refactoring/child/pom.xml", xmlLanguageService);
+		DOMDocument childXmlDocument = createDOMDocument("/property-refactoring/child/pom.xml", languageService);
+		languageService.didOpen(xmlDocument);
+
 		assertNotNull(childXmlDocument, "Child document not found!");
 		List<Range> childPropertyUseRanges =collectMavenPropertyUsages(childXmlDocument, propertyName);
 
@@ -209,14 +213,14 @@ public class MavenPropertyRenameParticipantTest {
 		Position startTagMiddle = xmlDocument.positionAt((startTagOpenOffset + startTagCloseOffset) / 2);
 
 		Either<Range, PrepareRenameResult> prepareResult = 
-				xmlLanguageService.prepareRename(xmlDocument, startTagMiddle, () -> {});
+				languageService.prepareRename(xmlDocument, startTagMiddle, () -> {});
 		assertNotNull(prepareResult, "Prepare Result is null!");
 		assertNotNull(prepareResult.getLeft(), "Prepare Result Range is null!");
 
 		Range prepareResultRange = prepareResult.getLeft();
 		assertEquals(expectedStartTagRange, prepareResultRange);
 
-		WorkspaceEdit renameReult = xmlLanguageService.doRename(xmlDocument, startTagMiddle, newPropertyName, () -> {});
+		WorkspaceEdit renameReult = languageService.doRename(xmlDocument, startTagMiddle, newPropertyName, () -> {});
 		assertNotNull(renameReult, "Prepare Result is null!");
 		assertNotNull(renameReult.getDocumentChanges(), "Rename result document changes is null!");
 		assertEquals(expectedRenameResult, renameReult);
@@ -224,14 +228,14 @@ public class MavenPropertyRenameParticipantTest {
 		// Test renaming end tag of maven property definition
 		Position endTagMiddle = xmlDocument.positionAt((endTagOpenOffset + endTagCloseOffset) / 2);
 
-		prepareResult = xmlLanguageService.prepareRename(xmlDocument, endTagMiddle, () -> {});
+		prepareResult = languageService.prepareRename(xmlDocument, endTagMiddle, () -> {});
 		assertNotNull(prepareResult, "Prepare Result is null!");
 		assertNotNull(prepareResult.getLeft(), "Prepare Result Range is null!");
 
 		prepareResultRange = prepareResult.getLeft();
 		assertEquals(expectedEndTagRange, prepareResultRange);
 
-		renameReult = xmlLanguageService.doRename(xmlDocument, endTagMiddle, newPropertyName, () -> {});
+		renameReult = languageService.doRename(xmlDocument, endTagMiddle, newPropertyName, () -> {});
 		assertNotNull(renameReult, "Prepare Result is null!");
 		assertNotNull(renameReult.getDocumentChanges(), "Rename result document changes is null!");
 		assertEquals(expectedRenameResult, renameReult);
@@ -242,14 +246,14 @@ public class MavenPropertyRenameParticipantTest {
 				(firstUse.getStart().getLine() + firstUse.getEnd().getLine()) / 2,
 				(firstUse.getStart().getCharacter() + firstUse.getEnd().getCharacter()) / 2);				
 
-		prepareResult = xmlLanguageService.prepareRename(xmlDocument, firstUseMiddle, () -> {});
+		prepareResult = languageService.prepareRename(xmlDocument, firstUseMiddle, () -> {});
 		assertNotNull(prepareResult, "Prepare Result is null!");
 		assertNotNull(prepareResult.getLeft(), "Prepare Result Range is null!");
 
 		prepareResultRange = prepareResult.getLeft();
 		assertEquals(expectedFirstUseRange, prepareResultRange);
 
-		renameReult = xmlLanguageService.doRename(xmlDocument, firstUseMiddle, newPropertyName, () -> {});
+		renameReult = languageService.doRename(xmlDocument, firstUseMiddle, newPropertyName, () -> {});
 		assertNotNull(renameReult, "Prepare Result is null!");
 		assertNotNull(renameReult.getDocumentChanges(), "Rename result document changes is null!");
 		assertEquals(expectedRenameResult, renameReult);

--- a/lemminx-maven/src/test/java/org/eclipse/lemminx/extensions/maven/utils/MavenLemminxTestsUtils.java
+++ b/lemminx-maven/src/test/java/org/eclipse/lemminx/extensions/maven/utils/MavenLemminxTestsUtils.java
@@ -53,7 +53,6 @@ public interface MavenLemminxTestsUtils {
 				throw new CancellationException("Call is cancelled on phase " + cancellingPhase);
 			}
 		}
-		
 	}
 
 	// Counts the 'checkCanceled()` calls for an operation 
@@ -68,13 +67,16 @@ public interface MavenLemminxTestsUtils {
 		public int getCounterValue() {
 			return counter;
 		}
-		
 	}
 
 	public static TextDocumentItem createTextDocumentItem(String resourcePath) throws IOException, URISyntaxException {
 		return createTextDocumentItem(resourcePath, null);
 	}
-
+	
+	public static TextDocumentItem createTextDocumentItem(URI uri) throws IOException, URISyntaxException {
+		return createTextDocumentItem(uri, null);
+	}
+	
 	public static DOMDocument createDOMDocument(String resourcePath, Properties replacements, XMLLanguageService languageService) throws IOException, URISyntaxException {
 		return org.eclipse.lemminx.dom.DOMParser.getInstance().parse(new TextDocument(createTextDocumentItem(resourcePath, replacements)), languageService.getResolverExtensionManager());
 	}
@@ -83,8 +85,16 @@ public interface MavenLemminxTestsUtils {
 		return org.eclipse.lemminx.dom.DOMParser.getInstance().parse(new TextDocument(createTextDocumentItem(resourcePath)), languageService.getResolverExtensionManager());
 	}
 
+	public static DOMDocument createDOMDocument(URI uri, XMLLanguageService languageService) throws IOException, URISyntaxException {
+		return org.eclipse.lemminx.dom.DOMParser.getInstance().parse(new TextDocument(createTextDocumentItem(uri)), languageService.getResolverExtensionManager());
+	}
+
 	public static TextDocumentItem createTextDocumentItem(String resourcePath, Properties replacements) throws IOException, URISyntaxException {
 		URI uri = MavenLemminxTestsUtils.class.getResource(resourcePath).toURI();
+		return createTextDocumentItem(uri, replacements);
+	}
+
+	public static TextDocumentItem createTextDocumentItem(URI uri, Properties replacements) throws IOException, URISyntaxException {
 		File file = new File(uri);
 		String contents = Files.readString(file.toPath());
 		if (replacements != null) {

--- a/lemminx-maven/src/test/java/org/eclipse/lemminx/extensions/maven/utils/ParticipantUtilsTest.java
+++ b/lemminx-maven/src/test/java/org/eclipse/lemminx/extensions/maven/utils/ParticipantUtilsTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2022 Red Hat Inc. and others.
+ * Copyright (c) 2022, 2023 Red Hat Inc. and others.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/
@@ -30,7 +30,6 @@ import org.eclipse.lemminx.extensions.maven.MavenLanguageService;
 import org.eclipse.lemminx.extensions.maven.MavenLemminxExtension;
 import org.eclipse.lemminx.extensions.maven.MavenProjectCache;
 import org.eclipse.lemminx.extensions.maven.NoMavenCentralExtension;
-import org.eclipse.lemminx.services.XMLLanguageService;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -38,7 +37,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 
 @ExtendWith(NoMavenCentralExtension.class)
 public class ParticipantUtilsTest {
-	private XMLLanguageService languageService;
+	private MavenLanguageService languageService;
 
 	@BeforeEach
 	public void setUp() throws IOException {
@@ -53,8 +52,12 @@ public class ParticipantUtilsTest {
 
 	@Test
 	public void testResolveValueWithProperties() throws IOException, URISyntaxException {
-		DOMDocument document = createDOMDocument("/pom-with-properties.xml", languageService);
 		MavenLemminxExtension plugin = new MavenLemminxExtension();
+		plugin.start(null,languageService);
+
+		DOMDocument document = createDOMDocument("/pom-with-properties.xml", languageService);
+		languageService.didOpen(document);
+		
 		MavenProjectCache cache = plugin.getProjectCache();
 		MavenProject project = cache.getLastSuccessfulMavenProject(document);
 		assertNotNull(project);


### PR DESCRIPTION
Make Maven Projects to be loaded/cached lazily when collecting the Workspace Artifacts when gathering completions n order to make content assist faster and more responsive

Issue: #444