### PR TITLE
Remote central repository can block Thread pooling

### DIFF
--- a/lemminx-maven/src/main/java/org/eclipse/lemminx/extensions/maven/MavenLemminxExtension.java
+++ b/lemminx-maven/src/main/java/org/eclipse/lemminx/extensions/maven/MavenLemminxExtension.java
@@ -533,6 +533,10 @@ public class MavenLemminxExtension implements IXMLExtension {
 			localRepositorySearcher.stop();
 			localRepositorySearcher = null;
 		}
+		if (centralSearcher != null) {
+			centralSearcher.stop();
+			centralSearcher = null;
+		}
 		cache = null;
 		if (container != null) {
 			container.dispose();

--- a/lemminx-maven/src/main/java/org/eclipse/lemminx/extensions/maven/searcher/RemoteCentralRepositorySearcher.java
+++ b/lemminx-maven/src/main/java/org/eclipse/lemminx/extensions/maven/searcher/RemoteCentralRepositorySearcher.java
@@ -15,7 +15,6 @@ import static org.eclipse.lemminx.extensions.maven.searcher.JsonRemoteCentralRep
 import static org.eclipse.lemminx.extensions.maven.searcher.JsonRemoteCentralRepositoryConstants.NUM_FOUND;
 import static org.eclipse.lemminx.extensions.maven.searcher.JsonRemoteCentralRepositoryConstants.RESPONSE;
 import static org.eclipse.lemminx.extensions.maven.searcher.JsonRemoteCentralRepositoryConstants.VERSION;
-
 import static org.eclipse.lemminx.utils.ExceptionUtils.getRootCause;
 
 import java.io.UnsupportedEncodingException;
@@ -24,15 +23,15 @@ import java.text.MessageFormat;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
-import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
-import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
 import java.util.TreeSet;
 import java.util.concurrent.Callable;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
 import java.util.logging.Level;
 import java.util.logging.Logger;
@@ -61,29 +60,41 @@ public class RemoteCentralRepositorySearcher {
 
 	public static final String SEARCH_URI = "https://search.maven.org/solrsearch/select?";
 	public static final String SEARCH_PARAMS = "wt=json&q=";
-	
+
 	public static final RemoteRepository CENTRAL_REPO = new RemoteRepository.Builder("central", "default",
 			"https://repo.maven.apache.org/maven2").build();
 
-	public static boolean disableCentralSearch = Boolean
-			.parseBoolean(System.getProperty(RemoteCentralRepositorySearcher.class.getName() + ".disableCentralSearch"));
+	public static boolean disableCentralSearch = Boolean.parseBoolean(
+			System.getProperty(RemoteCentralRepositorySearcher.class.getName() + ".disableCentralSearch"));
 
-	public static int cacheExpirationTimeoutMinutes = Integer
-			.parseInt(System.getProperty(RemoteCentralRepositorySearcher.class.getName() + ".cacheExpirationTimeoutMinutes", "-1"), 10);
+	private static int cacheExpirationTimeoutMinutes = Integer.parseInt(System
+			.getProperty(RemoteCentralRepositorySearcher.class.getName() + ".cacheExpirationTimeoutMinutes", "-1"), 10);
 
-	private OkHttpClient client = new OkHttpClient();
+	private final static long DEFAULT_CACHE_EXPIRATION_TIMEOUT = 30L;
+
+	private final OkHttpClient client;
+
+	private final ExecutorService executorService;
+
+	private final Cache<RequestKey, CompletableFuture<?>> cache;
+
+	private final CacheManager<RequestKey, Collection<Artifact>> artifactsCache;
+
+	private final CacheManager<RequestKey, Collection<String>> groupIdsCache;
+
+	private final CacheManager<RequestKey, Collection<ArtifactVersion>> artifactVersionsCache;
 
 	private enum RequestKind {
 		KIND_GET_GROUP_IDS("Get Group IDs"), //
 		KIND_GET_ARTIFACTS("Get Artifacts"), //
 		KIND_GET_ARTIFACT_VERSIONS("Get Artifact Versions"); //
-		
+
 		String kind;
-		
+
 		private RequestKind(String kind) {
 			this.kind = kind;
 		}
-		
+
 		public String getKindName() {
 			return kind;
 		}
@@ -94,36 +105,37 @@ public class RemoteCentralRepositorySearcher {
 		RequestKind kind;
 		Dependency artifact;
 		String packaging;
-		
+
 		public RequestKey(Request request, RequestKind kind, Dependency artifact, String packaging) {
 			this.request = request;
 			this.kind = kind;
 			this.artifact = artifact;
 			this.packaging = packaging;
 		}
-		
+
 		@Override
 		public boolean equals(Object obj) {
 			if (super.equals(obj)) {
 				return true;
 			}
 			if (obj instanceof RequestKey rdObj) {
-				return this.hashCode() ==rdObj.hashCode();
+				return this.hashCode() == rdObj.hashCode();
 			}
 			return false;
 		}
-		
+
 		@Override
 		public int hashCode() {
 			String requestString = request.toString();
-			String artifactString = artifact.toString(); 
+			String artifactString = artifact.toString();
 			return Objects.hash(requestString, kind, packaging, artifactString);
 		}
 	}
-	
+
 	public enum OngoingOperationError {
 		REMOTE_SEARCH_DISABLED("The Maven Search ''{0}'' operation is disabled."), //
-		REMOTE_SEARCH_OPERATION_IN_PROGRESS("The Maven Search ''{0}'' operation is in progress for artifact: ''{1}, packaging: ''{2}''."); //
+		REMOTE_SEARCH_OPERATION_IN_PROGRESS(
+				"The Maven Search ''{0}'' operation is in progress for artifact: ''{1}, packaging: ''{2}''."); //
 
 		private final String rawMessage;
 
@@ -135,7 +147,7 @@ public class RemoteCentralRepositorySearcher {
 			return MessageFormat.format(rawMessage, arguments);
 		}
 	}
-	
+
 	public static class OngoingOperationException extends RuntimeException {
 		private static final long serialVersionUID = 1L;
 
@@ -144,9 +156,10 @@ public class RemoteCentralRepositorySearcher {
 		private final OngoingOperationError errorCode;
 
 		@SuppressWarnings("rawtypes")
-		public OngoingOperationException(RequestKey requestDescriptor,
-				OngoingOperationError errorCode, CompletableFuture future, Throwable e) {
-			super(errorCode.getMessage(requestDescriptor.kind.getKindName(), requestDescriptor.artifact, requestDescriptor.packaging), e);
+		public OngoingOperationException(RequestKey requestDescriptor, OngoingOperationError errorCode,
+				CompletableFuture future, Throwable e) {
+			super(errorCode.getMessage(requestDescriptor.kind.getKindName(), requestDescriptor.artifact,
+					requestDescriptor.packaging), e);
 			this.errorCode = errorCode;
 			this.future = future;
 		}
@@ -161,147 +174,125 @@ public class RemoteCentralRepositorySearcher {
 		}
 	}
 
-	private static class CacheManager<RequeatKey,V> {
-		private static long DEFAULT_EXPIRATION_TIMEOUT = 30; 
+	private class CacheManager<RequeatKey, V> {
 
-		private long cacheExpirationTimeout = DEFAULT_EXPIRATION_TIMEOUT;
-		private Cache <RequestKey, V> cache;
-		private final Map<RequestKey, CompletableFuture<V>> ongoingSearches;
-		private final Cache<RequestKey, Exception> searchExceptions;
+		private final Cache<RequestKey, CompletableFuture<?>> cache;
 
-		public CacheManager(long expirationTimeoutMinutes) {
-			cacheExpirationTimeout = expirationTimeoutMinutes != -1 ? 
-					expirationTimeoutMinutes : DEFAULT_EXPIRATION_TIMEOUT;
-			cache = CacheBuilder.newBuilder()
-					.expireAfterWrite(cacheExpirationTimeout, TimeUnit.MINUTES)
-					.build();
-			searchExceptions = CacheBuilder.newBuilder()
-					.expireAfterWrite(cacheExpirationTimeout, TimeUnit.MINUTES)
-					.build();
-			ongoingSearches = new HashMap<>();
+		public CacheManager(Cache<RequestKey, CompletableFuture<?>> cache) {
+			this.cache = cache;
 		}
-		
+
 		V getAssync(RequestKey key, Callable<? extends V> loader) {
 			// If value is already cached - just return it
-			V cachedValue = cache.getIfPresent(key);
-			if (cachedValue != null) {
-				return cachedValue;
+			@SuppressWarnings("unchecked")
+			CompletableFuture<V> cachedValue = (CompletableFuture<V>) cache.getIfPresent(key);
+			if (cachedValue == null) {
+				synchronized (cache) {
+					cachedValue = callLoader(key, loader);
+					cache.put(key, cachedValue);
+				}
 			}
-
-			// If an exception is cached for the key - just return an empty 
-			// collection. The exception is already logged, so keep it as is
-			Exception cacheException = searchExceptions.getIfPresent(key);
-			if (cacheException != null) {
+			if (cachedValue.isCompletedExceptionally()) {
 				// There were an error while receiving results from
-				// Maven Search API, to avoid trying to repeat the 
+				// Maven Search API, to avoid trying to repeat the
 				// request on each key stroke - just exiting here.
-				// (TODO: Do we need to throw the last cached exception 
-				//        again?)
+				// (TODO: Do we need to throw the last cached exception
+				// again?)
 				return null;
 			}
-
-			CompletableFuture<V> f = null;
-			synchronized (ongoingSearches) {
+			if (!cachedValue.isDone()) {
 				// If a Maven Search API request is ongoing - just exiting here
-				// to avoid trying to repeat the request on each key stroke. 
-				// (TODO: Do we need to throw the last cached exception again 
-				//        providing a way to receive the ongoing search future?)
-				if (ongoingSearches.containsKey(key)) {
-					CompletableFuture<V> future = ongoingSearches.get(key);
-					throw new OngoingOperationException(key,
-							OngoingOperationError.REMOTE_SEARCH_OPERATION_IN_PROGRESS, 
-							future, null);
-				}
-
-				// Otherwise, process the request
-				f = callLoader(key, loader);
-				ongoingSearches.put(key, f);
+				// to avoid trying to repeat the request on each key stroke.
+				// (TODO: Do we need to throw the last cached exception again
+				// providing a way to receive the ongoing search future?)
+				throw new OngoingOperationException(key, OngoingOperationError.REMOTE_SEARCH_OPERATION_IN_PROGRESS,
+						cachedValue, null);
 			}
-
-			V result = f.getNow(null);
-			if (result == null) {
-				throw new OngoingOperationException(key,
-						OngoingOperationError.REMOTE_SEARCH_OPERATION_IN_PROGRESS, 
-						f, null);
-			}
-
-			return result;
+			return cachedValue.getNow(null);
 		}
-		
+
 		private CompletableFuture<V> callLoader(final RequestKey key, final Callable<? extends V> loader) {
 			return CompletableFuture.supplyAsync(() -> {
 				try {
-					V result =loader.call();
-					cache.put(key, result);
+					V result = loader.call();
 					return result;
 				} catch (Exception e) {
 					Throwable rootCause = getRootCause(e);
 					String error = "[" + rootCause.getClass().getTypeName() + "] " + rootCause.getMessage();
-					LOGGER.log(Level.SEVERE,
-							"Error while requesting data : " + error);
-					searchExceptions.put(key, e);
+					LOGGER.log(Level.SEVERE, "Error while requesting data : " + error);
 					return null;
-				} finally {
-					synchronized (ongoingSearches) {
-						ongoingSearches.remove(key);
-					}
 				}
-			});
+			}, executorService);
 		}
 	}
-	
+
 	public RemoteCentralRepositorySearcher() {
+		this.client = new OkHttpClient();
+		this.executorService = Executors.newFixedThreadPool(3);
+		this.cache = CacheBuilder.newBuilder() //
+				.expireAfterWrite(DEFAULT_CACHE_EXPIRATION_TIMEOUT, TimeUnit.MINUTES)//
+				.build();
+		this.artifactsCache = new CacheManager<RemoteCentralRepositorySearcher.RequestKey, Collection<Artifact>>(cache);
+		this.groupIdsCache = new CacheManager<RemoteCentralRepositorySearcher.RequestKey, Collection<String>>(cache);
+		this.artifactVersionsCache = new CacheManager<RemoteCentralRepositorySearcher.RequestKey, Collection<ArtifactVersion>>(
+				cache);
 	}
-	
+
 	public Collection<Artifact> getArtifacts(Dependency artifactToSearch) throws OngoingOperationException {
-		return disableCentralSearch ? Collections.emptySet() : internalGetArtifacts(artifactToSearch, PACKAGING_TYPE_JAR);
+		return disableCentralSearch ? Collections.emptySet()
+				: internalGetArtifacts(artifactToSearch, PACKAGING_TYPE_JAR);
 	}
-				
-	public Collection<ArtifactVersion> getArtifactVersions(Dependency artifactToSearch) throws OngoingOperationException {
-		return disableCentralSearch ? Collections.emptySet() : internalGetArtifactVersions(artifactToSearch, PACKAGING_TYPE_JAR);
+
+	public Collection<ArtifactVersion> getArtifactVersions(Dependency artifactToSearch)
+			throws OngoingOperationException {
+		return disableCentralSearch ? Collections.emptySet()
+				: internalGetArtifactVersions(artifactToSearch, PACKAGING_TYPE_JAR);
 	}
-	
-	public Collection<String> getGroupIds(Dependency artifactToSearch)  throws OngoingOperationException {
-		return disableCentralSearch ? Collections.emptySet() : internalGetGroupIds(artifactToSearch, PACKAGING_TYPE_JAR);
+
+	public Collection<String> getGroupIds(Dependency artifactToSearch) throws OngoingOperationException {
+		return disableCentralSearch ? Collections.emptySet()
+				: internalGetGroupIds(artifactToSearch, PACKAGING_TYPE_JAR);
 	}
 
 	public Collection<Artifact> getPluginArtifacts(Dependency artifactToSearch) throws OngoingOperationException {
-		return disableCentralSearch ? Collections.emptySet() : internalGetArtifacts(artifactToSearch, PACKAGING_TYPE_MAVEN_PLUGIN);
+		return disableCentralSearch ? Collections.emptySet()
+				: internalGetArtifacts(artifactToSearch, PACKAGING_TYPE_MAVEN_PLUGIN);
 	}
 
-	public Collection<ArtifactVersion> getPluginArtifactVersions(Dependency artifactToSearch) throws OngoingOperationException {
-		return disableCentralSearch ? Collections.emptySet() : internalGetArtifactVersions(artifactToSearch, PACKAGING_TYPE_MAVEN_PLUGIN);
+	public Collection<ArtifactVersion> getPluginArtifactVersions(Dependency artifactToSearch)
+			throws OngoingOperationException {
+		return disableCentralSearch ? Collections.emptySet()
+				: internalGetArtifactVersions(artifactToSearch, PACKAGING_TYPE_MAVEN_PLUGIN);
 	}
 
 	public Collection<String> getPluginGroupIds(Dependency artifactToSearch) throws OngoingOperationException {
-		return disableCentralSearch ? Collections.emptySet() : internalGetGroupIds(artifactToSearch, PACKAGING_TYPE_MAVEN_PLUGIN);
+		return disableCentralSearch ? Collections.emptySet()
+				: internalGetGroupIds(artifactToSearch, PACKAGING_TYPE_MAVEN_PLUGIN);
 	}
-	
-	private static CacheManager<RequestKey, Collection<Artifact>> artifactsCache = new CacheManager<>(cacheExpirationTimeoutMinutes);
+
 	private Collection<Artifact> internalGetArtifacts(Dependency artifactToSearch, String packaging) {
 		Request request = createArtifactIdsRequesty(artifactToSearch, packaging);
 		Collection<Artifact> result = artifactsCache.getAssync(
-				new RequestKey(request, RequestKind.KIND_GET_ARTIFACTS, artifactToSearch, packaging), 
+				new RequestKey(request, RequestKind.KIND_GET_ARTIFACTS, artifactToSearch, packaging),
 				new Callable<Collection<Artifact>>() {
-			@Override
-			public Collection<Artifact> call() throws Exception {
-				JsonObject responseBody = getResponseBody(request, artifactToSearch);
-				if (responseBody == null || responseBody.get(NUM_FOUND).getAsInt() <= 0 ) {
-					return Collections.emptyList();
-				}
+					@Override
+					public Collection<Artifact> call() throws Exception {
+						JsonObject responseBody = getResponseBody(request, artifactToSearch);
+						if (responseBody == null || responseBody.get(NUM_FOUND).getAsInt() <= 0) {
+							return Collections.emptyList();
+						}
 
-				List<Artifact> artifactInfos = new ArrayList<>();
-				responseBody.get(DOCS).getAsJsonArray().forEach(d -> {
-					artifactInfos.add(toArtifactInfo(d.getAsJsonObject()));
+						List<Artifact> artifactInfos = new ArrayList<>();
+						responseBody.get(DOCS).getAsJsonArray().forEach(d -> {
+							artifactInfos.add(toArtifactInfo(d.getAsJsonObject()));
+						});
+
+						return artifactInfos;
+					}
 				});
-				
-				return artifactInfos;
-			}
-		});
-		return result != null ? result : Collections.emptySet(); 
+		return result != null ? result : Collections.emptySet();
 	}
 
-	private static CacheManager<RequestKey, Collection<ArtifactVersion>> artifactVersionsCache = new CacheManager<>(cacheExpirationTimeoutMinutes);
 	private Collection<ArtifactVersion> internalGetArtifactVersions(Dependency artifactToSearch, String packaging) {
 		if (isEmpty(artifactToSearch.getArtifactId())) {
 			return Collections.emptySet();
@@ -309,54 +300,54 @@ public class RemoteCentralRepositorySearcher {
 
 		Request request = createArtifactVersionsRequest(artifactToSearch, packaging);
 		Collection<ArtifactVersion> result = artifactVersionsCache.getAssync(
-				new RequestKey(request, RequestKind.KIND_GET_ARTIFACT_VERSIONS, artifactToSearch, packaging), 
+				new RequestKey(request, RequestKind.KIND_GET_ARTIFACT_VERSIONS, artifactToSearch, packaging),
 				new Callable<Collection<ArtifactVersion>>() {
-			@Override
-			public Collection<ArtifactVersion> call() throws Exception {
-				JsonObject responseBody = getResponseBody(request, artifactToSearch);
-				if (responseBody == null || responseBody.get(NUM_FOUND).getAsInt() <= 0 ) {
-					return Collections.emptySet();
-				}
-	
-				Set<ArtifactVersion> artifactVersions = new HashSet<ArtifactVersion>();
-				responseBody.get(DOCS).getAsJsonArray().forEach(d -> {
-					artifactVersions.add(new DefaultArtifactVersion(d.getAsJsonObject().get(VERSION).getAsString()));
+					@Override
+					public Collection<ArtifactVersion> call() throws Exception {
+						JsonObject responseBody = getResponseBody(request, artifactToSearch);
+						if (responseBody == null || responseBody.get(NUM_FOUND).getAsInt() <= 0) {
+							return Collections.emptySet();
+						}
+
+						Set<ArtifactVersion> artifactVersions = new HashSet<ArtifactVersion>();
+						responseBody.get(DOCS).getAsJsonArray().forEach(d -> {
+							artifactVersions
+									.add(new DefaultArtifactVersion(d.getAsJsonObject().get(VERSION).getAsString()));
+						});
+
+						return artifactVersions;
+					}
 				});
-	
-				return artifactVersions;
-			}
-		});
-		return result != null ? result : Collections.emptySet(); 
+		return result != null ? result : Collections.emptySet();
 	}
-	
-	private static CacheManager<RequestKey, Collection<String>> groupIdsCache = new CacheManager<>(cacheExpirationTimeoutMinutes);
+
 	private Collection<String> internalGetGroupIds(Dependency artifactToSearch, String packaging) {
 		if (isEmpty(artifactToSearch.getGroupId())) {
 			return Collections.emptySet();
 		}
-		
+
 		Request request = createGroupIdsRequest(artifactToSearch, packaging);
 		Collection<String> result = groupIdsCache.getAssync(
-				new RequestKey(request, RequestKind.KIND_GET_GROUP_IDS, artifactToSearch, packaging), 
+				new RequestKey(request, RequestKind.KIND_GET_GROUP_IDS, artifactToSearch, packaging),
 				new Callable<Collection<String>>() {
-			@Override
-			public Collection<String> call() throws Exception {
-				JsonObject responseBody = getResponseBody(request, artifactToSearch);
-				if (responseBody == null || responseBody.get(NUM_FOUND).getAsInt() <= 0 ) {
-					return Collections.emptySet();
-				}
-				
-				Collection<String> artifactGroupIds = new TreeSet<>(String.CASE_INSENSITIVE_ORDER);
-				responseBody.get(DOCS).getAsJsonArray().forEach(d -> {
-					artifactGroupIds.add(d.getAsJsonObject().get(GROUP_ID).getAsString());
+					@Override
+					public Collection<String> call() throws Exception {
+						JsonObject responseBody = getResponseBody(request, artifactToSearch);
+						if (responseBody == null || responseBody.get(NUM_FOUND).getAsInt() <= 0) {
+							return Collections.emptySet();
+						}
+
+						Collection<String> artifactGroupIds = new TreeSet<>(String.CASE_INSENSITIVE_ORDER);
+						responseBody.get(DOCS).getAsJsonArray().forEach(d -> {
+							artifactGroupIds.add(d.getAsJsonObject().get(GROUP_ID).getAsString());
+						});
+
+						return artifactGroupIds;
+					}
 				});
-				
-				return artifactGroupIds;
-			}
-		});
-		return result != null ? result : Collections.emptySet(); 
+		return result != null ? result : Collections.emptySet();
 	}
-	
+
 	private static Request createGroupIdsRequest(Dependency artifactToSearch, String packaging) {
 		StringBuilder query = new StringBuilder();
 		query.append("p:").append(packaging).append(" AND ").append("g:");
@@ -367,56 +358,58 @@ public class RemoteCentralRepositorySearcher {
 
 		final StringBuilder url = new StringBuilder();
 		try {
-			url.append(SEARCH_URI).append("rows=200&")
-				.append(SEARCH_PARAMS).append(URLEncoder.encode(query.toString(), "UTF-8"));
-		} catch(UnsupportedEncodingException ex) {
-			LOGGER.log(Level.SEVERE, "Maven Central Repo search failed for " + String.join(":", artifactToSearch.getGroupId(),
-					artifactToSearch.getArtifactId(), artifactToSearch.getVersion()), ex.getMessage());
+			url.append(SEARCH_URI).append("rows=200&").append(SEARCH_PARAMS)
+					.append(URLEncoder.encode(query.toString(), "UTF-8"));
+		} catch (UnsupportedEncodingException ex) {
+			LOGGER.log(Level.SEVERE, "Maven Central Repo search failed for " + String.join(":",
+					artifactToSearch.getGroupId(), artifactToSearch.getArtifactId(), artifactToSearch.getVersion()),
+					ex.getMessage());
 			return null;
 		}
 		return new Request.Builder().url(url.toString()).build();
 	}
-	
+
 	private static Request createArtifactIdsRequesty(Dependency artifactToSearch, String packaging) {
 		StringBuilder query = new StringBuilder();
 		query.append("p:").append(packaging);
 
-	    if(!isEmpty(artifactToSearch.getGroupId())) {
+		if (!isEmpty(artifactToSearch.getGroupId())) {
 			query.append(" AND ").append("g:\"").append(artifactToSearch.getGroupId()).append("\"");
-	    }
-	    if(!isEmpty(artifactToSearch.getArtifactId())) {
-    		query.append(" AND ").append("a:").append(artifactToSearch.getArtifactId()).append("*");
-	    }
+		}
+		if (!isEmpty(artifactToSearch.getArtifactId())) {
+			query.append(" AND ").append("a:").append(artifactToSearch.getArtifactId()).append("*");
+		}
 
 		final StringBuilder url = new StringBuilder();
 		try {
-			url.append(SEARCH_URI).append("rows=100&")
-				.append(SEARCH_PARAMS).append(URLEncoder.encode(query.toString(), "UTF-8"));
-		} catch(UnsupportedEncodingException ex) {
-			LOGGER.log(Level.SEVERE, "Maven Central Repo search failed for " + String.join(":", artifactToSearch.getGroupId(),
-					artifactToSearch.getArtifactId(), artifactToSearch.getVersion()), ex.getMessage());
+			url.append(SEARCH_URI).append("rows=100&").append(SEARCH_PARAMS)
+					.append(URLEncoder.encode(query.toString(), "UTF-8"));
+		} catch (UnsupportedEncodingException ex) {
+			LOGGER.log(Level.SEVERE, "Maven Central Repo search failed for " + String.join(":",
+					artifactToSearch.getGroupId(), artifactToSearch.getArtifactId(), artifactToSearch.getVersion()),
+					ex.getMessage());
 			return null;
 		}
 		return new Request.Builder().url(url.toString()).build();
 	}
-	
+
 	private static Request createArtifactVersionsRequest(Dependency artifactToSearch, String packaging) {
 		StringBuilder query = new StringBuilder();
-		query.append("p:").append(packaging).append(" AND ")
-			.append("g:").append(artifactToSearch.getGroupId()).append(" AND ")
-			.append("a:").append(artifactToSearch.getArtifactId());
+		query.append("p:").append(packaging).append(" AND ").append("g:").append(artifactToSearch.getGroupId())
+				.append(" AND ").append("a:").append(artifactToSearch.getArtifactId());
 
-	    if(!isEmpty(artifactToSearch.getVersion())) {
+		if (!isEmpty(artifactToSearch.getVersion())) {
 			query.append(" AND v:").append(artifactToSearch.getVersion()).append("*");
-	    }
+		}
 
 		final StringBuilder url = new StringBuilder();
 		try {
-			url.append(SEARCH_URI).append("rows=100&core=gav&")
-				.append(SEARCH_PARAMS).append(URLEncoder.encode(query.toString(), "UTF-8"));
-		} catch(UnsupportedEncodingException ex) {
-			LOGGER.log(Level.SEVERE, "Maven Central Repo search failed for " + String.join(":", artifactToSearch.getGroupId(),
-					artifactToSearch.getArtifactId(), artifactToSearch.getVersion()), ex.getMessage());
+			url.append(SEARCH_URI).append("rows=100&core=gav&").append(SEARCH_PARAMS)
+					.append(URLEncoder.encode(query.toString(), "UTF-8"));
+		} catch (UnsupportedEncodingException ex) {
+			LOGGER.log(Level.SEVERE, "Maven Central Repo search failed for " + String.join(":",
+					artifactToSearch.getGroupId(), artifactToSearch.getArtifactId(), artifactToSearch.getVersion()),
+					ex.getMessage());
 			return null;
 		}
 		return new Request.Builder().url(url.toString()).build();
@@ -428,14 +421,14 @@ public class RemoteCentralRepositorySearcher {
 			JsonObject bodyObject = JsonParser.parseReader(response.body().charStream()).getAsJsonObject();
 			if (bodyObject.has(RESPONSE)) {
 				JsonObject responseObject = bodyObject.get(RESPONSE).getAsJsonObject();
-				if (responseObject.has(NUM_FOUND) &&
-						responseObject.has(DOCS)) {
+				if (responseObject.has(NUM_FOUND) && responseObject.has(DOCS)) {
 					return responseObject;
 				}
 			}
 		} else {
-			LOGGER.log(Level.SEVERE, "Maven Central Repo search failed for " + String.join(":", artifactToSearch.getGroupId(),
-					artifactToSearch.getArtifactId(), artifactToSearch.getVersion()), response.message());
+			LOGGER.log(Level.SEVERE, "Maven Central Repo search failed for " + String.join(":",
+					artifactToSearch.getGroupId(), artifactToSearch.getArtifactId(), artifactToSearch.getVersion()),
+					response.message());
 		}
 		return null;
 	}
@@ -447,8 +440,12 @@ public class RemoteCentralRepositorySearcher {
 		Artifact artifactInfo = new DefaultArtifact(g, a, null, v);
 		return artifactInfo;
 	}
-	
+
 	private static final boolean isEmpty(String s) {
 		return s == null || s.trim().isEmpty();
+	}
+
+	public void stop() {
+		executorService.shutdown();
 	}
 }


### PR DESCRIPTION
This PR improves remote central repository : 

 * use 1 cache instead of 3 * 3 caches (just one Thread instead of 9)
 * fix problem with use of synchronized which could bock Thread and don't gree the Thread in the pooling.