### PR TITLE
Maven repository is polluted with not existing dependencies

### DIFF
--- a/lemminx-maven/src/main/java/org/eclipse/lemminx/extensions/maven/utils/LocalRepositoryUtils.java
+++ b/lemminx-maven/src/main/java/org/eclipse/lemminx/extensions/maven/utils/LocalRepositoryUtils.java
@@ -1,0 +1,121 @@
+/*******************************************************************************
+ * Copyright (c) 2023 Red Hat Inc. and others.
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ * Angelo Zerr <angelo.zerr@gmail.com> - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.lemminx.extensions.maven.utils;
+
+import java.io.File;
+import java.util.List;
+import java.util.stream.Stream;
+
+import org.apache.maven.execution.MavenExecutionRequest;
+import org.apache.maven.repository.RepositorySystem;
+import org.eclipse.lemminx.extensions.maven.settings.XMLMavenSettings;
+
+/**
+ * Utilities to compute the local repository path.
+ * 
+ */
+public class LocalRepositoryUtils {
+
+	private static final String LEMMINX_MAVEN = ".lemminx-maven";
+	private static final String MAVEN_REPO_LOCAL_TAIL = "maven.repo.local.tail";
+	public static final String MAVEN_LOCAL_REPO_PROPERTY_NAME = "maven.repo.local";
+
+	private LocalRepositoryUtils() {
+
+	}
+
+	/**
+	 * Update the local repository path of the maven request:
+	 * 
+	 * <ul>
+	 * <li>the main local repository is a temporary directory
+	 * ${userName}.m2/.lemminx-maven where artifacts,metadata files are downloaded
+	 * when pom.xml is editing.</li>
+	 * <li>the user local repository is registered as 'maven repo tail' to avoid
+	 * download artifacts, metada files in this folder.
+	 * </ul>
+	 * 
+	 * @param mavenRequest the maven request to update
+	 * @param options      the maven settings.
+	 */
+	public static void updateLocalRepositoryPath(MavenExecutionRequest mavenRequest, XMLMavenSettings options) {
+		File localRepositoryDir = getLocalRepositoryDir(options, mavenRequest.getLocalRepositoryPath());
+
+		// When artifact are resolved, aether create folders and some metadata files
+		// To avoid polluting the user local repository with those metadata files we:
+
+		// 1. create a temporary dir (ex: ${userName}.m2/.lemminx-maven) and we
+		// configure
+		// maven request with this local repository
+		// When user will type some wrong artifact, the metadata files will be
+		// downloaded in this temporary dir
+		File tempLocalRepositoryPath = getTempLocalRepositoryPath(localRepositoryDir);
+		tempLocalRepositoryPath.mkdirs();
+		mavenRequest.setLocalRepositoryPath(tempLocalRepositoryPath);
+
+		// 2. add the use local repository as 'maven repo tail' (maven.repo.local.tail)
+		// to use it this local repository to find artifacts
+		mavenRequest.getUserProperties().put(MAVEN_REPO_LOCAL_TAIL, localRepositoryDir.toString());
+	}
+
+	/**
+	 * Returns the all local repository path that user have configured from the
+	 * maven request.
+	 * 
+	 * @param mavenRequest the maven request.
+	 * @return the all local repository path that user have configured from the
+	 *         maven request.
+	 */
+	public static List<File> getLocalRepositoryPaths(MavenExecutionRequest mavenRequest) {
+		String tail = (String) mavenRequest.getUserProperties().get(MAVEN_REPO_LOCAL_TAIL);
+		return Stream.of(tail.split(",")) //
+				.map(dir -> new File(dir)) //
+				.toList();
+
+	}
+
+	/**
+	 * Returns the temporary local repository path computed according the user local
+	 * repository path.
+	 * 
+	 * @param localRepositoryDir the user local repository path
+	 * @return the temporary local repository path computed according the user local
+	 *         repository path.
+	 */
+	public static File getTempLocalRepositoryPath(File localRepositoryDir) {
+		return new File(localRepositoryDir.getParentFile(), LEMMINX_MAVEN);
+	}
+
+	private static File getLocalRepositoryDir(XMLMavenSettings options, File defaultLocalRepositoryPath) {
+		// 1) Try to search local repository from the settings
+		String fromSettings = options.getRepo().getLocal();
+		if (fromSettings != null && !fromSettings.trim().isEmpty()) {
+			File candidate = new File(fromSettings);
+			if (candidate.isDirectory() && candidate.canRead()) {
+				return candidate;
+			}
+		}
+
+		// 2) Try to search the local repository from the System
+		String fromSystem = System.getProperty(MAVEN_LOCAL_REPO_PROPERTY_NAME);
+		if (fromSystem != null) {
+			return new File(fromSystem);
+		}
+
+		if (defaultLocalRepositoryPath != null) {
+			return defaultLocalRepositoryPath;
+		}
+		// 3) Returns the default local repository ${userName}/.m2/repository
+		return RepositorySystem.defaultUserLocalRepository;
+	}
+
+}

--- a/lemminx-maven/src/test/java/org/eclipse/lemminx/extensions/maven/InitMavenRequestTest.java
+++ b/lemminx-maven/src/test/java/org/eclipse/lemminx/extensions/maven/InitMavenRequestTest.java
@@ -8,6 +8,9 @@
  *******************************************************************************/
 package org.eclipse.lemminx.extensions.maven;
 
+import static org.eclipse.lemminx.extensions.maven.utils.LocalRepositoryUtils.getLocalRepositoryPaths;
+import static org.eclipse.lemminx.extensions.maven.utils.LocalRepositoryUtils.getTempLocalRepositoryPath;
+import static org.eclipse.lemminx.extensions.maven.utils.LocalRepositoryUtils.MAVEN_LOCAL_REPO_PROPERTY_NAME;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.fail;
@@ -18,6 +21,8 @@ import java.io.FileWriter;
 import java.io.IOException;
 import java.util.Properties;
 
+import org.apache.maven.execution.MavenExecutionRequest;
+import org.eclipse.aether.RepositorySystemSession;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -26,7 +31,6 @@ import org.junit.jupiter.api.extension.ExtendWith;
 public class InitMavenRequestTest {
 
 	private static final String TEST_LOCAL_REPO_PATH = "/.m2/bug383repository";
-	private static final String MAVEN_LOCAL_REPO_PROPERTY_NAME = "maven.repo.local";
 	
 	private static final String TEST_DUMMY_PROPERTY_NAME = "DUMMY_USER_HOME";
 	private static final String HOSTNAME_ENV_VARIABLE_NAME = isWindows() ? "COMPUTERNAME" : "HOSTNAME";
@@ -57,10 +61,20 @@ public class InitMavenRequestTest {
 			plugin.settings.setGlobalSettings(null);
 			plugin.settings.setUserSettings(localSettingsFile.getAbsolutePath());
 			
-			File localRepositoryPath = plugin.getMavenSession().getRequest().getLocalRepositoryPath();
-			File expectedLocalRepoPath = new File(hostname, TEST_LOCAL_REPO_PATH); 
-			assertNotNull(localRepositoryPath);
-			assertEquals(expectedLocalRepoPath.getAbsolutePath(), localRepositoryPath.getAbsolutePath());
+			MavenExecutionRequest mavenRequest = plugin.getMavenSession().getRequest();			
+			File expectedLocalRepoPath = new File(hostname, TEST_LOCAL_REPO_PATH);
+			
+			// Test with temporary lemminx-maven local repository
+			File expectedTempLocalRepoPath = getTempLocalRepositoryPath(expectedLocalRepoPath);
+			File actualTempLocalRepoPath = mavenRequest.getLocalRepositoryPath();
+			assertNotNull(actualTempLocalRepoPath);
+			assertEquals(expectedTempLocalRepoPath.getAbsolutePath(), actualTempLocalRepoPath.getAbsolutePath());
+			
+			// Test with the real local repository
+			File actualLocalRepoPath = getLocalRepositoryPaths(mavenRequest).get(0);
+			assertNotNull(actualLocalRepoPath);
+			assertEquals(expectedLocalRepoPath.getAbsolutePath(), actualLocalRepoPath.getAbsolutePath());
+			
 		} finally {
 			if (localSettingsFile != null) {
 				localSettingsFile.delete();
@@ -90,10 +104,20 @@ public class InitMavenRequestTest {
 			plugin.settings.setGlobalSettings(null);
 			plugin.settings.setUserSettings(localSettingsFile.getAbsolutePath());
 			
-			File localRepositoryPath = plugin.getMavenSession().getRequest().getLocalRepositoryPath();
-			File expectedLocalRepoPath = new File(mavenProjectBasedirVariable, TEST_LOCAL_REPO_PATH); 
-			assertNotNull(localRepositoryPath);
-			assertEquals(expectedLocalRepoPath.getAbsolutePath(), localRepositoryPath.getAbsolutePath());
+			MavenExecutionRequest mavenRequest = plugin.getMavenSession().getRequest();			
+			File expectedLocalRepoPath = new File(mavenProjectBasedirVariable, TEST_LOCAL_REPO_PATH);
+			
+			// Test with temporary lemminx-maven local repository
+			File expectedTempLocalRepoPath = getTempLocalRepositoryPath(expectedLocalRepoPath);
+			File actualTempLocalRepoPath = mavenRequest.getLocalRepositoryPath();
+			assertNotNull(actualTempLocalRepoPath);
+			assertEquals(expectedTempLocalRepoPath.getAbsolutePath(), actualTempLocalRepoPath.getAbsolutePath());
+			
+			// Test with the real local repository
+			File actualLocalRepoPath = getLocalRepositoryPaths(mavenRequest).get(0);
+			assertNotNull(actualLocalRepoPath);
+			assertEquals(expectedLocalRepoPath.getAbsolutePath(), actualLocalRepoPath.getAbsolutePath());
+			
 		} finally {
 			if (localSettingsFile != null) {
 				localSettingsFile.delete();
@@ -122,10 +146,20 @@ public class InitMavenRequestTest {
 			plugin.settings.setGlobalSettings(null);
 			plugin.settings.setUserSettings(localSettingsFile.getAbsolutePath());
 			
-			File localRepositoryPath = plugin.getMavenSession().getRequest().getLocalRepositoryPath();
-			File expectedLocalRepoPath = new File(homeVariable, TEST_LOCAL_REPO_PATH); 
-			assertNotNull(localRepositoryPath);
-			assertEquals(expectedLocalRepoPath.getAbsolutePath(), localRepositoryPath.getAbsolutePath());
+			MavenExecutionRequest mavenRequest = plugin.getMavenSession().getRequest();			
+			File expectedLocalRepoPath = new File(homeVariable, TEST_LOCAL_REPO_PATH);
+			
+			// Test with temporary lemminx-maven local repository
+			File expectedTempLocalRepoPath = getTempLocalRepositoryPath(expectedLocalRepoPath);
+			File actualTempLocalRepoPath = mavenRequest.getLocalRepositoryPath();
+			assertNotNull(actualTempLocalRepoPath);
+			assertEquals(expectedTempLocalRepoPath.getAbsolutePath(), actualTempLocalRepoPath.getAbsolutePath());
+			
+			// Test with the real local repository
+			File actualLocalRepoPath = getLocalRepositoryPaths(mavenRequest).get(0);
+			assertNotNull(actualLocalRepoPath);
+			assertEquals(expectedLocalRepoPath.getAbsolutePath(), actualLocalRepoPath.getAbsolutePath());
+
 		} finally {
 			if (localSettingsFile != null) {
 				localSettingsFile.delete();


### PR DESCRIPTION
Maven repository is polluted with not existing dependencies

Fixes #213

Take a sample with the user local repository `${userName}/.m2/repository`

This PR fixes #213 by:

 * setting the local repository of maven request to a dir different from the local user repository `${userName}/.m2/.lemminx-maven`. This local repository will contains all metadata files downaloded by aether when artifacts dependencies occurs.
 * register the user local repository `${userName}/.m2/repository` as a second local repository (with the property maven.repo.local.tail) to use it to find artifacts. This folder will never polluated with the aether metadata files when user is typing in the editor.