### PR TITLE
Fix NPE in MavenLemminxExtension.stop

### DIFF
--- a/lemminx-maven/src/main/java/org/eclipse/lemminx/extensions/maven/MavenLemminxExtension.java
+++ b/lemminx-maven/src/main/java/org/eclipse/lemminx/extensions/maven/MavenLemminxExtension.java
@@ -537,7 +537,10 @@ public class MavenLemminxExtension implements IXMLExtension {
 			centralSearcher.stop();
 			centralSearcher = null;
 		}
-		cache = null;
+		if (cache != null) {
+			cache.stop();
+			cache = null;
+		}
 		if (container != null) {
 			container.dispose();
 			container = null;
@@ -547,7 +550,6 @@ public class MavenLemminxExtension implements IXMLExtension {
 		if (mavenInitializer != null) {
 			mavenInitializer.cancel(true);
 		}
-		cache.stop();
 	}
 
 	/**


### PR DESCRIPTION
```
SEVERE: Error while stopping extension <org.eclipse.lemminx.extensions.maven.MavenLemminxExtension>
java.lang.NullPointerException: Cannot invoke "org.eclipse.lemminx.extensions.maven.project.MavenProjectCache.stop()" because "this.cache" is null
	at org.eclipse.lemminx.extensions.maven.MavenLemminxExtension.stop(MavenLemminxExtension.java:554)
	at org.eclipse.lemminx.services.extensions.XMLExtensionsRegistry.unregisterExtension(XMLExtensionsRegistry.java:296)
	at java.base/java.util.ArrayList.forEach(ArrayList.java:1511)
	at org.eclipse.lemminx.services.extensions.XMLExtensionsRegistry.dispose(XMLExtensionsRegistry.java:309)
	at org.eclipse.lemminx.extensions.maven.participants.hover.MavenHoverCancellationTest.tearDown(MavenHoverCancellationTest.java:47)
```