### PR TITLE
Fixed updating the  Local Repository caches

### DIFF
--- a/lemminx-maven/src/main/java/org/eclipse/lemminx/extensions/maven/MavenInitializationException.java
+++ b/lemminx-maven/src/main/java/org/eclipse/lemminx/extensions/maven/MavenInitializationException.java
@@ -8,7 +8,7 @@
  *******************************************************************************/
 package org.eclipse.lemminx.extensions.maven;
 
-import java.util.concurrent.CancellationException;
+import java.util.concurrent.CompletableFuture;
 
 /**
  * Exception thrown when Maven is initializing.
@@ -16,6 +16,17 @@ import java.util.concurrent.CancellationException;
  * @author Angelo ZERR
  *
  */
-public class MavenInitializationException extends CancellationException{
+public class MavenInitializationException extends RuntimeException {
+	private static final long serialVersionUID = 6811208967929378721L;
+	
+	private final CompletableFuture<Void> future;
 
+	public MavenInitializationException(CompletableFuture<Void> future) {
+		super();
+		this.future = future;
+	}
+
+	public CompletableFuture<Void> getFuture() {
+		return future;
+	}
 }

--- a/lemminx-maven/src/main/java/org/eclipse/lemminx/extensions/maven/participants/diagnostics/MavenDiagnosticParticipant.java
+++ b/lemminx-maven/src/main/java/org/eclipse/lemminx/extensions/maven/participants/diagnostics/MavenDiagnosticParticipant.java
@@ -135,9 +135,15 @@ public class MavenDiagnosticParticipant implements IDiagnosticsParticipant {
 					node.getChildren().stream().filter(DOMElement.class::isInstance).forEach(nodes::push);
 				}
 			}
-		} catch (MavenInitializationException | MavenModelOutOfDatedException e) {
+		} catch (MavenInitializationException e) {
 			// - Maven is initializing
-			// - or parse of maven model with DOM document is out of dated
+			CompletableFuture<Void> initFuture = e.getFuture();
+			if (initFuture != null) {
+				initFuture.thenAccept( unused -> plugin.getValidationService()
+						.validate(xmlDocument));
+			}
+		} catch (MavenModelOutOfDatedException e) {
+			// - Parse of maven model with DOM document is out of dated
 			// -> catch the error to avoid breaking XML diagnostics from LemMinX
 		}
 	}

--- a/lemminx-maven/src/main/java/org/eclipse/lemminx/extensions/maven/project/IMavenProjectBuildListener.java
+++ b/lemminx-maven/src/main/java/org/eclipse/lemminx/extensions/maven/project/IMavenProjectBuildListener.java
@@ -1,0 +1,28 @@
+/*******************************************************************************
+ * Copyright (c) 2023 Red Hat Inc. and others.
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+package org.eclipse.lemminx.extensions.maven.project;
+
+import java.io.File;
+
+import org.apache.maven.project.MavenProject;
+
+/**
+ * A listener to be used to be notified when a new or updated Maven Project is 
+ * built and cached.
+ */
+public interface IMavenProjectBuildListener {
+	
+	/**
+	 * Called when a new or updated Maven Project is built and cached
+	 * 
+	 * @param repository A repository holding the project's built artifacts
+	 * @param mavenProject A new/updated Maven Project
+	 */
+	void builtMavenProject(File repository, MavenProject mavenProject);
+}

--- a/lemminx-maven/src/main/java/org/eclipse/lemminx/extensions/maven/searcher/LocalRepositorySearcher.java
+++ b/lemminx-maven/src/main/java/org/eclipse/lemminx/extensions/maven/searcher/LocalRepositorySearcher.java
@@ -13,20 +13,19 @@ import static org.eclipse.lemminx.extensions.maven.utils.ParticipantUtils.isWell
 import java.io.File;
 import java.io.IOException;
 import java.nio.file.DirectoryStream;
-import java.nio.file.FileVisitResult;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.nio.file.SimpleFileVisitor;
-import java.nio.file.attribute.BasicFileAttributes;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
+import java.util.concurrent.CancellationException;
 import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.CompletionException;
+import java.util.concurrent.ExecutionException;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import java.util.stream.Collectors;
@@ -34,11 +33,13 @@ import java.util.stream.Collectors;
 import org.apache.maven.artifact.versioning.ArtifactVersion;
 import org.apache.maven.artifact.versioning.DefaultArtifactVersion;
 import org.apache.maven.model.Dependency;
+import org.apache.maven.project.MavenProject;
 import org.eclipse.aether.artifact.Artifact;
 import org.eclipse.aether.artifact.DefaultArtifact;
 import org.eclipse.lemminx.commons.progress.ProgressMonitor;
 import org.eclipse.lemminx.commons.progress.ProgressSupport;
 import org.eclipse.lemminx.extensions.maven.MavenLemminxExtension;
+import org.eclipse.lemminx.extensions.maven.project.IMavenProjectBuildListener;
 import org.eclipse.lsp4j.jsonrpc.CancelChecker;
 import org.eclipse.lsp4j.jsonrpc.CompletableFutures;
 
@@ -46,22 +47,285 @@ import org.eclipse.lsp4j.jsonrpc.CompletableFutures;
  * Search for collecting artifacts from the local repository /.m2
  *
  */
-public class LocalRepositorySearcher {
+public class LocalRepositorySearcher implements IMavenProjectBuildListener {
 
 	private static final Logger LOGGER = Logger.getLogger(LocalRepositorySearcher.class.getName());
-
+	private static long REPOSITORY_UPDATE_PERIOD = 30*60*1000; // 30 minutes
+	
 	private final ProgressSupport progressSupport;
+	private Map<File, Cache> cache = new HashMap<>();
+	private Thread updaterThread;
 
-	private Map<File, CompletableFuture<Collection<Artifact>>> cache = new HashMap<>();
+	class Cache {
+		private File repository;
+		private Map<Path, Artifact> artifacts;
+		private CompletableFuture<Collection<Artifact>> future;
+		private boolean updateRequested = false;
+		
+		Cache (File repository) {
+			this.repository = repository;
+			this.artifacts = new HashMap<>();
+		}
+		
+		public File getRepository() {
+			return repository;
+		}
 
-	private CompletableFuture<Collection<Artifact>> loadAllLocalArtifacts;
+		public void cancel() {
+			if (future != null) {
+				try {
+					future.cancel(true);
+				} catch (CancellationException e) {
+					// Ignore
+					e.printStackTrace();
+				}
+				future = null;
+			}
+		}
 
+		CompletableFuture<Collection<Artifact>> getArtifacts() {
+			synchronized (this) {
+				if (future == null || future.isCompletedExceptionally()) {
+					future = repository == null 
+							? CompletableFuture.completedFuture(artifacts.values())
+							: CompletableFutures.computeAsync(cancelChecker -> doUpdate(true, cancelChecker));
+				}
+			}
+			return future;
+		}
+		
+		public void updateBuiltArtifact(Artifact artifact) {
+			if (artifact != null) {
+				Path groupPath = new File(repository, artifact.getGroupId().replace('.', File.separatorChar)).toPath();
+				Path artifactPath = groupPath.resolve(artifact.getArtifactId());
+				Path versionPath = artifactPath.resolve(artifact.getVersion());
+				
+				Artifact probe = probeDirectoryForArtifact(versionPath, () -> {});
+				if (probe != null) {
+					synchronized (this) {
+						artifacts.put(artifactPath, probe);
+					}
+				}
+			}			
+		}
+		
+		private Collection<Artifact> doUpdate(boolean initial, CancelChecker cancelChecker) {
+			UpdaterProgressMonitor pm = new UpdaterProgressMonitor(true);
+			try {
+				pm.begin();
+				Collection<Path> toRemove = artifacts.keySet().stream()
+						.collect(Collectors.toList()); 
+				pm.incrementTotal(toRemove.size());
+				updateArtifacts(repository.toPath(), toRemove, pm, cancelChecker);
+				for (Path path : toRemove) {
+					pm.report(path.getFileName().toString());
+					synchronized (this) {
+						artifacts.remove(path);
+					}
+				}
+			} finally {
+				pm.end();
+			}
+			return artifacts.values();
+		}
+		
+		private void updateArtifacts() {
+			synchronized (this) {
+				if (future == null || future.isDone()) {
+					// Replace the existing completed future
+					LOGGER.info("Starting local repository cache update for ''" + repository + "''...");
+					updateRequested = false;
+					future = repository == null 
+							? CompletableFuture.completedFuture(artifacts.values())
+							: CompletableFutures.computeAsync(cancelChecker -> doUpdate(true, cancelChecker));
+					future.whenComplete((ok, error) -> {
+						if (error != null && !(error instanceof CancellationException)) {
+							LOGGER.log(Level.SEVERE, "Local repository cache update failed for : ''" + repository + "'': " + error.getMessage(),  error);
+						}
+						LOGGER.info("Finished local repository cache update for ''" + repository + "''...");
+					});
+				} else {
+					if (!updateRequested) {
+						// Re-schedule update after the current future is completed
+						LOGGER.info("Re-scheduling local repository cache update for ''" + repository + "''...");
+						updateRequested = true;
+						future.whenComplete((ok, error) -> {
+							updateArtifacts();
+						});
+					} else {
+						LOGGER.info("Skipping local repository cache update  for ''" + repository + "'' - already scheduled");
+					}
+				}
+			}
+		}
+		
+		class UpdaterProgressMonitor {
+			private ProgressMonitor monitor;
+			private int total = 0;
+			private int completed = 0;
+			private int lastReportedPercentage = -1;
+			private boolean initial;
+			
+			public UpdaterProgressMonitor(boolean initial) {
+				this.initial = initial;
+			}
+			
+			int incrementTotal(int delta) {
+				this.total += delta;
+				return this.total;
+			}
+			
+			int incrementCompleted(int delta) {
+				this.completed += delta;
+				return this.completed;
+			}
+			
+			Integer percentage() {
+				if (total == 0 || completed >total) {
+					return 100;
+				}
+				return 100 * completed / total;
+			}
+			
+			void begin() {
+				if (monitor == null) {
+					monitor = progressSupport != null ? progressSupport.createProgressMonitor() : null;
+					if (monitor != null) {
+						monitor.begin((initial ? "Loading" : "Updating") 
+								+ " local artifacts from ''" + repository.toPath() + "''...", 
+								null, 100, null);
+					}
+				}
+			}
+			
+			void report(String entry) {
+				var newCoompleted = incrementCompleted(1);
+				if (monitor != null) {
+					// Limiting report counts to 10 (one after each 10%-progress)
+					int percentage = percentage();
+					if (lastReportedPercentage < 0 || percentage >=100 
+							|| (percentage / 10 - lastReportedPercentage / 10) % 10 >= 1) {
+						monitor.report("Scanning folder ''" + entry  + "'' (" + newCoompleted + " / "
+								+ total + ")...", percentage(), null);
+						lastReportedPercentage = percentage;
+					}
+				}
+			}
+			
+			void end() {
+				if (monitor != null) {
+					monitor.end("Finished loading local artifacts from ''" + repository.toPath() + "''.");
+				}
+			}
+		}
+		
+		private Collection<Artifact> updateArtifacts(Path dir, Collection<Path> oldPaths, UpdaterProgressMonitor progressMonitor, CancelChecker cancelChecker) {
+			List<Path> subPaths = getSubDirectories(dir);
+			progressMonitor.incrementTotal(subPaths.size());
+			Artifact latestArtifact = null;
+			ArtifactVersion latestVersion = null;
+			for (Path entry : subPaths) {
+				progressMonitor.report(entry.getFileName().toString());
+				if (Files.isDirectory(entry)) {
+					if (oldPaths.remove(dir)) {
+						progressMonitor.incrementTotal(-1);
+					}
+					Artifact artifact = probeDirectoryForArtifact(entry, cancelChecker);
+					if (artifact != null) {
+						ArtifactVersion version = new DefaultArtifactVersion(artifact.getVersion());
+						if (latestArtifact == null || latestVersion.compareTo(version) < 0) {
+							latestArtifact = artifact;
+							latestVersion = version;
+						}
+					}
+					updateArtifacts(entry, oldPaths, progressMonitor, cancelChecker);
+				}
+			}
+			if (latestArtifact != null) {
+				// Add or replace the existing artifact if the version is newer
+				Artifact outdatedArtifact = artifacts.get(dir);
+				if (outdatedArtifact == null 
+						|| latestVersion.compareTo(new DefaultArtifactVersion(
+								outdatedArtifact.getVersion())) > 0) {
+					synchronized (this) {
+						artifacts.put(dir, latestArtifact);
+					}  
+				}
+			} else {
+				// Remove outdated artifact 
+				Artifact outdatedArtifact = artifacts.get(dir);
+				if (outdatedArtifact != null) {
+					synchronized (this) {
+						artifacts.remove(dir);
+					}  
+				}
+			}
+			return artifacts.values();
+		}
+
+		private Artifact probeDirectoryForArtifact(Path dir, CancelChecker cancelChecker) {
+			if (dir.getFileName().toString().charAt(0) == '.') {
+				cancelChecker.checkCanceled();
+				return null;
+			}
+			if (!Character.isDigit(dir.getFileName().toString().charAt(0))) {
+				cancelChecker.checkCanceled();
+				return null;
+			}
+			Path artifactFolderPath = repository.toPath().relativize(dir);
+			if (artifactFolderPath.getNameCount() < 3) {
+				cancelChecker.checkCanceled();
+				// eg "maven-dependency-plugin/3.1.2"
+				return null;
+			}
+			ArtifactVersion version = new DefaultArtifactVersion(artifactFolderPath.getFileName().toString());
+			String artifactId = artifactFolderPath.getParent().getFileName().toString();
+			String groupId = artifactFolderPath.getParent().getParent().toString()
+					.replace(artifactFolderPath.getFileSystem().getSeparator(), ".");
+			if (!new File(dir.toFile(), artifactId + '-' + version.toString() + ".pom").isFile()) {
+				cancelChecker.checkCanceled();
+				return null;
+			}
+			cancelChecker.checkCanceled();
+			return new DefaultArtifact(groupId, artifactId, null, version.toString());
+		}
+		
+		private static List<Path> getSubDirectories(Path directoryPath) {
+			List<Path> subDirectories = new ArrayList<>();
+			try (DirectoryStream<Path> directoryStream = Files.newDirectoryStream(directoryPath)) {
+				for (Path entry : directoryStream) {
+					if (Files.isDirectory(entry)) {
+						subDirectories.add(entry);
+					}
+				}
+			} catch (IOException e) {
+				// Do nothing
+			}
+			return subDirectories;
+		}
+	}
+	
 	public LocalRepositorySearcher(Set<File> localRepositoryDirs, ProgressSupport progressSupport) {
 		this.progressSupport = progressSupport;
 		// Force the load of the local artifacts done in background
-		for (File localRepositoryDir : localRepositoryDirs) {
-			createLocalArtifactsFuture(localRepositoryDir);
-		}
+		localRepositoryDirs.stream().filter(Objects::nonNull)
+			.forEach(this::createLocalLocalRepositoryCache);
+		this.updaterThread = new Thread(() -> {
+			try {
+				LOGGER.log(Level.INFO, "Local repo updater started");
+				while (true) {
+					Thread.sleep(REPOSITORY_UPDATE_PERIOD);
+					try {
+						LocalRepositorySearcher.this.updateArtifacts();
+					} catch (CancellationException e) {
+						// Ignore
+					}
+				}
+			} catch (InterruptedException e) {
+				LOGGER.log(Level.INFO, "Local repo updater stopped");
+			}
+		});
+		updaterThread.start();
 	}
 
 	public Set<String> searchGroupIds() throws IOException {
@@ -85,25 +349,20 @@ public class LocalRepositorySearcher {
 	 *         repository.
 	 */
 	public Collection<Artifact> getLocalArtifactsLastVersion() {
-		if (loadAllLocalArtifacts == null || loadAllLocalArtifacts.isCompletedExceptionally()) {
-			loadAllLocalArtifacts = getOrCreateLocalArtifactsLastVersion();
-		}
-		if (loadAllLocalArtifacts.isDone()) {
-			return loadAllLocalArtifacts.getNow(Collections.emptyList());
-		}
-		// The local artifacts search is not finished, returns an empty list
-		return Collections.emptyList();
-	}
-
-	private synchronized CompletableFuture<Collection<Artifact>> getOrCreateLocalArtifactsLastVersion() {
-		if (!(loadAllLocalArtifacts == null || loadAllLocalArtifacts.isCompletedExceptionally())) {
-			return loadAllLocalArtifacts;
-		}
-		loadAllLocalArtifacts = allOf(cache.values());
-		return loadAllLocalArtifacts;
+		return allOf(cache.values().stream().map(Cache::getArtifacts).toList())
+				.getNow(Collections.emptyList());
 	}
 
 	private static <T> CompletableFuture<Collection<T>> allOf(Collection<CompletableFuture<Collection<T>>> futures) {
+		return CompletableFuture.allOf(futures.toArray(new CompletableFuture[futures.size()])) //
+				.thenApply(__ -> futures.stream() //
+						.map(future -> future.getNow(null))
+						.filter(Objects::nonNull)
+						.flatMap(list -> list.stream())
+						.toList());
+	}
+
+	private static <T> CompletableFuture<Collection<T>> joinAllOf(Collection<CompletableFuture<Collection<T>>> futures) {
 		return CompletableFuture.allOf(futures.toArray(new CompletableFuture[futures.size()])) //
 				.thenApply(__ -> futures.stream() //
 						.map(CompletableFuture::join) //
@@ -111,123 +370,27 @@ public class LocalRepositorySearcher {
 						.toList());
 	}
 
-	private void createLocalArtifactsFuture(File localRepository) {
-		CompletableFuture<Collection<Artifact>> loadLocalArtifacts = cache.get(localRepository);
-		if (loadLocalArtifacts == null || loadLocalArtifacts.isCompletedExceptionally()) {
-			if (MavenLemminxExtension.isUnitTestMode()) {
-				try {
-					loadLocalArtifacts = CompletableFuture
-							.completedFuture(computeLocalArtifacts(localRepository, () -> {
-							}));
-				} catch (IOException e) {
-					LOGGER.log(Level.SEVERE, "Local repo loading error", e);
+	private void createLocalLocalRepositoryCache(File localRepository) {
+		Cache repositoryCcache = cache.get(localRepository);
+		if (repositoryCcache == null) {
+			synchronized (cache) {
+				repositoryCcache = cache.get(localRepository);
+				if (repositoryCcache == null) {
+					repositoryCcache = new Cache(localRepository);
+					cache.put(localRepository, repositoryCcache);
 				}
-			} else {
-				// Load local artifacts on background
-				loadLocalArtifacts = CompletableFutures.computeAsync(cancelChecker -> {
-					try {
-						return computeLocalArtifacts(localRepository, cancelChecker);
-					} catch (IOException e) {
-						throw new CompletionException(e);
-					}
-				});
-			}
-
-			// Update the cache
-			cache.put(localRepository, loadLocalArtifacts);
-		}
-	}
-
-	private Collection<Artifact> computeLocalArtifacts(File localRepository, CancelChecker cancelChecker)
-			throws IOException {
-		final Path repoPath = localRepository.toPath();
-		ProgressMonitor progressMonitor = progressSupport != null ? progressSupport.createProgressMonitor() : null;
-		if (progressMonitor != null) {
-			progressMonitor.begin("Loading local artifacts from '" + repoPath, null, 100, null);
-		}
-		Map<String, Artifact> groupIdArtifactIdToVersion = new HashMap<>();
-		try {
-			List<Path> subPaths = getSubDirectories(repoPath);
-			int increment = Math.round(100f / subPaths.size());
-			int i = 0;
-			for (Path path : subPaths) {
-				cancelChecker.checkCanceled();
-				if (progressMonitor != null) {
-					progressMonitor.report("scanning folder' " + path.getFileName().getName(0) + "' (" + i++ + "/"
-							+ subPaths.size() + ")...", increment++, null);
-				}
-				try {
-					collect(path, repoPath, groupIdArtifactIdToVersion, cancelChecker);
-				} catch (IOException e) {
-					LOGGER.log(Level.SEVERE, "Error while scanning local repo folder " + path, e);
-				}
-			}
-		} finally {
-			if (progressMonitor != null) {
-				progressMonitor.end(null);
 			}
 		}
-		return groupIdArtifactIdToVersion.values();
-	}
-
-	private void collect(final Path currentPath, final Path repoPath, Map<String, Artifact> groupIdArtifactIdToVersion,
-			CancelChecker cancelChecker) throws IOException {
-		Files.walkFileTree(currentPath, Collections.emptySet(), 10, new SimpleFileVisitor<Path>() {
-			@Override
-			public FileVisitResult preVisitDirectory(Path file, BasicFileAttributes attrs) throws IOException {
-				if (file.getFileName().toString().charAt(0) == '.') {
-					cancelChecker.checkCanceled();
-					return FileVisitResult.SKIP_SUBTREE;
-				}
-				if (!Character.isDigit(file.getFileName().toString().charAt(0))) {
-					cancelChecker.checkCanceled();
-					return FileVisitResult.CONTINUE;
-				}
-				Path artifactFolderPath = repoPath.relativize(file);
-				if (artifactFolderPath.getNameCount() < 3) {
-					cancelChecker.checkCanceled();
-					// eg "maven-dependency-plugin/3.1.2"
-					return FileVisitResult.SKIP_SUBTREE;
-				}
-				ArtifactVersion version = new DefaultArtifactVersion(artifactFolderPath.getFileName().toString());
-				String artifactId = artifactFolderPath.getParent().getFileName().toString();
-				String groupId = artifactFolderPath.getParent().getParent().toString()
-						.replace(artifactFolderPath.getFileSystem().getSeparator(), ".");
-				if (!new File(file.toFile(), artifactId + '-' + version.toString() + ".pom").isFile()) {
-					cancelChecker.checkCanceled();
-					return FileVisitResult.SKIP_SUBTREE;
-				}
-				String groupIdArtifactId = groupId + ':' + artifactId;
-				Artifact existingGav = groupIdArtifactIdToVersion.get(groupIdArtifactId);
-				boolean replace = existingGav == null;
-				if (existingGav != null) {
-					ArtifactVersion existingVersion = new DefaultArtifactVersion(existingGav.getVersion());
-					replace |= existingVersion.compareTo(version) < 0;
-					replace |= (existingVersion.toString().endsWith("-SNAPSHOT")
-							&& !version.toString().endsWith("-SNAPSHOT"));
-				}
-				if (replace) {
-					groupIdArtifactIdToVersion.put(groupIdArtifactId,
-							new DefaultArtifact(groupId, artifactId, null, version.toString()));
-				}
-				cancelChecker.checkCanceled();
-				return FileVisitResult.SKIP_SUBTREE;
+		
+		CompletableFuture<Collection<Artifact>> future = repositoryCcache.getArtifacts();
+		if (MavenLemminxExtension.isUnitTestMode()) {
+			try {
+				future.get();
+			} catch (InterruptedException | ExecutionException e) {
+				LOGGER.log(Level.SEVERE, "Local repository cache creation failed for ''"
+						+ localRepository + "''", e);
 			}
-		});
-	}
-
-	private static List<Path> getSubDirectories(Path directoryPath) {
-		List<Path> subDirectories = new ArrayList<>();
-		try (DirectoryStream<Path> directoryStream = Files.newDirectoryStream(directoryPath)) {
-			for (Path entry : directoryStream) {
-				if (Files.isDirectory(entry)) {
-					subDirectories.add(entry);
-				}
-			}
-		} catch (IOException e) {
-			// Do nothing
 		}
-		return subDirectories;
 	}
 
 	// TODO consider using directly ArtifactRepository for those 2 methods
@@ -263,12 +426,55 @@ public class LocalRepositorySearcher {
 
 	public void stop() {
 		// Stop the thread which collects local repository artifacts
-		cache.values().forEach(f -> f.cancel(true));
-		cache.clear();
-		if (loadAllLocalArtifacts != null) {
-			loadAllLocalArtifacts.cancel(true);
-			loadAllLocalArtifacts = null;
+		if (updaterThread != null) {
+			updaterThread.interrupt();
+			updaterThread = null;
+		}
+		synchronized (cache) {
+			try {
+				cache.values().forEach(Cache::cancel);
+				cache.clear();
+			} catch (CancellationException e) {
+				// Ignore
+			}
 		}
 	}
 
+	public void updateArtifacts() {
+		cache.keySet().stream().forEach(repository -> {
+			Cache repositoryCache = cache.get(repository);
+			if (repositoryCache != null) {
+				repositoryCache.updateArtifacts();
+			}
+		});
+	}
+
+	@Override
+	public void builtMavenProject(File repository, MavenProject mavenProject) {
+		Artifact artifact = toArtifact(mavenProject.getArtifact());
+		if (artifact == null) {
+			return;
+		}
+		
+		synchronized (cache) {
+			Cache repositoryCache = cache.get(repository);
+			if (repositoryCache != null) {
+				repositoryCache.updateBuiltArtifact(artifact);
+				mavenProject.getArtifacts().stream()
+					.map(this::toArtifact)
+					.filter(Objects::nonNull)
+					.forEach(repositoryCache::updateBuiltArtifact);
+			}
+		}
+	}
+	
+	private Artifact toArtifact(org.apache.maven.artifact.Artifact mavenArtifact) {
+		Artifact artifact = new DefaultArtifact(
+				mavenArtifact.getGroupId(), 
+				mavenArtifact.getArtifactId(), 
+				null,
+				mavenArtifact.getVersion());
+		artifact.setFile(mavenArtifact.getFile());
+		return artifact;
+	}
 }

--- a/lemminx-maven/src/main/java/org/eclipse/lemminx/extensions/maven/utils/MavenPluginUtils.java
+++ b/lemminx-maven/src/main/java/org/eclipse/lemminx/extensions/maven/utils/MavenPluginUtils.java
@@ -15,7 +15,6 @@ import static org.eclipse.lemminx.extensions.maven.DOMConstants.GOAL_ELT;
 import static org.eclipse.lemminx.extensions.maven.DOMConstants.GROUP_ID_ELT;
 import static org.eclipse.lemminx.extensions.maven.DOMConstants.PLUGIN_ELT;
 
-import java.io.IOException;
 import java.util.Collections;
 import java.util.Comparator;
 import java.util.List;
@@ -223,7 +222,7 @@ public class MavenPluginUtils {
 				project.getRemotePluginRepositories().stream().collect(Collectors.toList()),
 				lemminxMavenPlugin.getMavenSession().getRepositorySession());
 		} catch (PluginResolutionException | PluginDescriptorParsingException | InvalidPluginDescriptorException ex) {
-			LOGGER.log(Level.WARNING, ex.getMessage(), ex);
+			LOGGER.log(Level.WARNING, ex.getMessage());
 			if (reThrowPluginDescriptorExceptions) {
 				throw ex; // Needed for plugin validation
 			}

--- a/lemminx-maven/src/test/java/org/eclipse/lemminx/extensions/maven/participants/PluginResolutionTest.java
+++ b/lemminx-maven/src/test/java/org/eclipse/lemminx/extensions/maven/participants/PluginResolutionTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2020-2023 Red Hat Inc. and others.
+ * Copyright (c) 2020, 2023 Red Hat Inc. and others.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/
@@ -69,6 +69,7 @@ public class PluginResolutionTest {
 		}
 		FileUtils.deleteDirectory(initialMavenPluginApiDirectory);
 		MavenLemminxTestsUtils.prefetchMavenXSD();
+		MavenLemminxExtension.setUnitTestMode(true);
 	}
 
 	@AfterEach
@@ -106,6 +107,8 @@ public class PluginResolutionTest {
     public void testPluginGoalValidationWithPluginWithJDKProfiles()
             throws IOException, InterruptedException, ExecutionException, URISyntaxException {
         MavenLemminxExtension plugin = new MavenLemminxExtension();
+		plugin.start(null,languageService);
+
         MavenDiagnosticParticipant mavenDiagnosticParticipant = new MavenDiagnosticParticipant(plugin);
         languageService.getDiagnosticsParticipants().add(mavenDiagnosticParticipant);
         List<Diagnostic> diagnostics = languageService.doDiagnostics(createDOMDocument("/pom-plugin-goal-resolution.xml", languageService),
@@ -119,6 +122,8 @@ public class PluginResolutionTest {
     public void testPluginManagementWithoutGroupId()
             throws IOException, InterruptedException, ExecutionException, URISyntaxException {
         MavenLemminxExtension plugin = new MavenLemminxExtension();
+		plugin.start(null,languageService);
+
         MavenDiagnosticParticipant mavenDiagnosticParticipant = new MavenDiagnosticParticipant(plugin);
         languageService.getDiagnosticsParticipants().add(mavenDiagnosticParticipant);
         List<Diagnostic> diagnostics = languageService.doDiagnostics(createDOMDocument("/pom-pluginManagement-unresolved.xml", languageService),


### PR DESCRIPTION
Local Repository caches are made to be updated:

- (only temporary lemminx-maven build repository) when a MavenProject is built and cached
- (all cached) every 30 minutes

Also, Diagnostic is made to be re-calculated on finishing of Maven Lemminx Extension initialization