### PR TITLE
Downgrade Maven wrapper to 3.9.2

### DIFF
--- a/.mvn/wrapper/maven-wrapper.properties
+++ b/.mvn/wrapper/maven-wrapper.properties
@@ -14,5 +14,5 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-distributionUrl=https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.9.5/apache-maven-3.9.5-bin.zip
+distributionUrl=https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.9.2/apache-maven-3.9.2-bin.zip
 wrapperUrl=https://repo.maven.apache.org/maven2/org/apache/maven/wrapper/maven-wrapper/3.1.0/maven-wrapper-3.1.0.jar


### PR DESCRIPTION
Workaround for tests failures happening with Maven > 3.9.2

> [ERROR]   MavenCompletionParticipantTest.testOneExistingDependencyDependenciesCompletionAdjustIndentation:103 maven-core - org.apache.maven:maven-core:3.0 should only exist once: Actual: dependency,flexmark-ext-gfm-tasklist - com.vladsch.flexmark:flexmark-ext-gfm-tasklist:0.42.14,aether-spi - org.eclipse.aether:aether-spi:1.0.0.v20140518,http-client-spi - software.amazon.awssdk:http-client-spi:2.10.35,maven-artifact-manager - org.apache.maven:maven-artifact-manager:2.2.1,doxia-module-docbook-simple - org.apache.maven.doxia:doxia-module-docbook-simple:1.11.1,org.ow2.sat4j.pb - org.ow2.sat4j:org.ow2.sat4j.pb:2.3.6,xercesMinimal - nekohtml:xercesMinimal:1.9.6.2,asm - org.ow2.asm:asm:9.5,flexmark-ext-admonition - com.vladsch.flexmark:flexmark-ext-admonition:0.42.14,flexmark-ext-enumerated-reference - com.vladsch.flexmark:flexmark-ext-enumerated-reference:0.42.14,maven-reporting-impl - org.apache.maven.reporting:maven-reporting-impl:3.2.0,payara-bom - fish.payara.api:payara-bom:5.2022.3,jakarta.json-api - jakarta.json:jakarta.json-api:2.1.0,jetty-xml - org.eclipse.jetty:jetty-xml:9.4.46.v20220331,genesis-default-flava - org.apache.geronimo.genesis:genesis-default-flava:2.0,guava - com.google.guava:guava:16.0.1,plexus-languages - org.codehaus.plexus:plexus-languages:0.9.10,maven-parent - org.apache.maven:maven-parent:39,commons-cli - commons-cli:commons-cli:1.2,protocol-core - software.amazon.awssdk:protocol-core:2.10.35,aether-api - org.sonatype.aether:aether-api:1.7,aether-util - org.eclipse.aether:aether-util:1.0.0.v20140518,commons-exec - org.apache.commons:commons-exec:1.3,mojo-parent - org.codehaus.mojo:mojo-parent:28,bom - software.amazon.awssdk:bom:2.10.35,org.eclipse.equinox.registry - org.eclipse.platform:org.eclipse.equinox.registry:3.11.300,sisu-osgi-connect - org.eclipse.tycho:sisu-osgi-connect:3.0.0,flexmark-ext-anchorlink - com.vladsch.flexmark:flexmark-ext-anchorlink:0.42.14,flexmark-ext-jekyll-front-matter - com.vladsch.flexmark:flexmark-ext-jekyll-front-matter:0.42.14,autolink - org.nibor.autolink:autolink:0.6.0,org.eclipse.equinox.simpleconfigurator - org.eclipse.platform:org.eclipse.equinox.simpleconfigurator:1.4.300,org.eclipse.equinox.p2.jarprocessor - org.eclipse.platform:org.eclipse.equinox.p2.jarprocessor:1.3.200,tyrus-bom - org.glassfish.tyrus:tyrus-bom:1.17.payara-p2,bcprov-jdk18on - org.bouncycastle:bcprov-jdk18on:1.71,kotlin-bom - org.jetbrains.kotlin:kotlin-bom:1.4.21,infinispan-bom - org.infinispan:infinispan-bom:11.0.15.Final,org.eclipse.tycho.p2.maven.repository - org.eclipse.tycho:org.eclipse.tycho.p2.maven.repository:3.0.0,xbean-reflect - org.apache.xbean:xbean-reflect:3.7,jakarta.xml.ws-api - jakarta.xml.ws:jakarta.xml.ws-api:4.0.0,jackson-base - com.fasterxml.jackson:jackson-base:2.10.0,tycho-p2-facade - org.eclipse.tycho:tycho-p2-facade:2.7.5,org.eclipse.equinox.p2.touchpoint.eclipse - org.eclipse.platform:org.eclipse.equinox.p2.touchpoint.eclipse:2.3.300,commons-lang - commons-lang:commons-lang:2.4,rpc-api-parent - jakarta.xml.rpc:rpc-api-parent:1.1.4,org.eclipse.equinox.preferences - org.eclipse.platform:org.eclipse.equinox.preferences:3.10.300,netty-reactive-streams-http - com.typesafe.netty:netty-reactive-streams-http:2.0.3,httpcore - org.apache.httpcomponents:httpcore:4.4.14,flexmark-ext-definition - com.vladsch.flexmark:flexmark-ext-definition:0.42.14,aether - org.eclipse.aether:aether:1.0.0.v20140518,org.eclipse.equinox.p2.publisher.eclipse - org.eclipse.platform:org.eclipse.equinox.p2.publisher.eclipse:1.4.100,hk2-bom - org.glassfish.hk2:hk2-bom:2.6.1.payara-p7,avalon-framework - avalon-framework:avalon-framework:4.1.3,flexmark-ext-gitlab - com.vladsch.flexmark:flexmark-ext-gitlab:0.42.14,flexmark-html-parser - com.vladsch.flexmark:flexmark-html-parser:0.42.14,commons-parent - org.apache.commons:commons-parent:56,org.eclipse.tycho.p2.resolver.shared - org.eclipse.tycho:org.eclipse.tycho.p2.resolver.shared:3.0.0,maven-assembly-plugin - org.apache.maven.plugins:maven-assembly-plugin:3.6.0,vorbis-support - com.github.trilarion:vorbis-support:1.1.0,jakarta.persistence-api - jakarta.persistence:jakarta.persistence-api:3.1.0,jackson-core - com.fasterxml.jackson.core:jackson-core:2.10.0,google - com.google:google:1,doxia-module-apt - org.apache.maven.doxia:doxia-module-apt:1.11.1,log4j - log4j:log4j:1.2.12,guava-parent - com.google.guava:guava-parent:16.0.1,jetty-http - org.eclipse.jetty:jetty-http:9.4.46.v20220331,flexmark-ext-aside - com.vladsch.flexmark:flexmark-ext-aside:0.42.14,org.ow2.sat4j.core - org.ow2.sat4j:org.ow2.sat4j.core:2.3.6,aether-api - org.eclipse.aether:aether-api:1.0.0.v20140518,maven-artifact - org.apache.maven:maven-artifact:3.2.5,plexus - org.codehaus.plexus:plexus:10,org.eclipse.tycho.noopsecurity - org.eclipse.tycho:org.eclipse.tycho.noopsecurity:3.0.0,osgi.annotation - org.osgi:osgi.annotation:8.0.1,flexmark-util - com.vladsch.flexmark:flexmark-util:0.42.14,maven-aether-provider - org.apache.maven:maven-aether-provider:3.2.5,jakarta.authorization-api - jakarta.authorization:jakarta.authorization-api:2.1.0,ant-launcher - org.apache.ant:ant-launcher:1.9.4,org.osgi.service.prefs - org.osgi:org.osgi.service.prefs:1.1.2,jakarta.enterprise.cdi-api - jakarta.enterprise:jakarta.enterprise.cdi-api:4.0.1,commons-codec - commons-codec:commons-codec:1.15,doxia-integration-tools - org.apache.maven.doxia:doxia-integration-tools:1.11.1,maven-compiler-plugin - org.apache.maven.plugins:maven-compiler-plugin:3.8.1,org.eclipse.equinox.concurrent - org.eclipse.platform:org.eclipse.equinox.concurrent:1.2.100,xbean - org.apache.xbean:xbean:3.7,wagon-providers - org.apache.maven.wagon:wagon-providers:1.0-beta-6,objenesis - org.objenesis:objenesis:1.0,eventstream - software.amazon.eventstream:eventstream:1.0.1,plexus-sec-dispatcher - org.sonatype.plexus:plexus-sec-dispatcher:1.3,sisu-inject-bean - org.sonatype.sisu:sisu-inject-bean:1.4.2,jersey-bom - org.glassfish.jersey:jersey-bom:2.34.payara-p2,maven-embedder - org.apache.maven:maven-embedder:3.0,logkit - logkit:logkit:1.0.1,sisu-inject - org.sonatype.sisu:sisu-inject:1.4.2,maven-dependency-analyzer - org.apache.maven.shared:maven-dependency-analyzer:1.13.2,org.eclipse.equinox.simpleconfigurator.manipulator - org.eclipse.platform:org.eclipse.equinox.simpleconfigurator.manipulator:2.2.200,commons-logging - commons-logging:commons-logging:1.2,flexmark-ext-attributes - com.vladsch.flexmark:flexmark-ext-attributes:0.42.14,org.eclipse.core.contenttype - org.eclipse.platform:org.eclipse.core.contenttype:3.9.100,flexmark-ext-escaped-character - com.vladsch.flexmark:flexmark-ext-escaped-character:0.42.14,bcpg-jdk18on - org.bouncycastle:bcpg-jdk18on:1.71,guice-plexus - org.sonatype.sisu.inject:guice-plexus:1.4.2,oss-parent - com.fasterxml:oss-parent:41,tycho-p2 - org.eclipse.tycho:tycho-p2:2.7.5,junit-platform-runner - org.junit.platform:junit-platform-runner:1.8.1,jakarta.jakartaee-web-api - jakarta.platform:jakarta.jakartaee-web-api:10.0.0,plexus-classworlds - org.codehaus.plexus:plexus-classworlds:2.6.0,doxia-modules - org.apache.maven.doxia:doxia-modules:1.11.1,jakarta.faces-api - jakarta.faces:jakarta.faces-api:4.0.1,commons-io - commons-io:commons-io:2.11.0,slf4j-nop - org.slf4j:slf4j-nop:1.5.3,oss-parent - org.sonatype.oss:oss-parent:9,jakarta.enterprise.concurrent-api - jakarta.enterprise.concurrent:jakarta.enterprise.concurrent-api:1.1.2,core - software.amazon.awssdk:core:2.10.35,flexmark-ext-toc - com.vladsch.flexmark:flexmark-ext-toc:0.42.14,doxia-module-xdoc - org.apache.maven.doxia:doxia-module-xdoc:1.11.1,weld-parent - org.jboss.weld:weld-parent:26,sisu-guice - org.sonatype.sisu:sisu-guice:3.2.3,org.eclipse.equinox.p2.garbagecollector - org.eclipse.platform:org.eclipse.equinox.p2.garbagecollector:1.3.100,maven-toolchain - org.apache.maven:maven-toolchain:2.2.1,wagon - org.apache.maven.wagon:wagon:1.0-beta-6,xml.registry-api-parent - jakarta.xml.registry:xml.registry-api-parent:1.0.10,spring-expression - org.springframework:spring-expression:5.3.3,plexus-interactivity - org.codehaus.plexus:plexus-interactivity:1.0-alpha-6,plexus-interactivity-api - org.codehaus.plexus:plexus-interactivity-api:1.0-alpha-6,rsocket-bom - io.rsocket:rsocket-bom:1.1.0,flexmark-ext-yaml-front-matter - com.vladsch.flexmark:flexmark-ext-yaml-front-matter:0.42.14,slf4j-parent - org.slf4j:slf4j-parent:2.0.6,jakarta.jms-api - jakarta.jms:jakarta.jms-api:3.1.0,wagon-http-shared - org.apache.maven.wagon:wagon-http-shared:1.0-beta-6,dom4j - dom4j:dom4j:1.1,spring-boot-dependencies - org.springframework.boot:spring-boot-dependencies:2.4.2,bcprov-jdk15on - org.bouncycastle:bcprov-jdk15on:1.70,jakarta.security.enterprise-api - jakarta.security.enterprise:jakarta.security.enterprise-api:3.0.0,http-clients - software.amazon.awssdk:http-clients:2.10.35,classworlds - classworlds:classworlds:1.1,org.eclipse.equinox.p2.repository - org.eclipse.platform:org.eclipse.equinox.p2.repository:2.7.100,org.eclipse.equinox.common - org.eclipse.platform:org.eclipse.equinox.common:3.18.100,flexmark-ext-gfm-tables - com.vladsch.flexmark:flexmark-ext-gfm-tables:0.42.14,jackrabbit-parent - org.apache.jackrabbit:jackrabbit-parent:1.5.0,doxia - org.apache.maven.doxia:doxia:1.11.1,maven-compat - org.apache.maven:maven-compat:3.0,maven-dependency-plugin - org.apache.maven.plugins:maven-dependency-plugin:3.6.0,jetty-util - org.eclipse.jetty:jetty-util:9.4.46.v20220331,commons-text - org.apache.commons:commons-text:1.10.0,jakarta.enterprise.cdi-parent - jakarta.enterprise:jakarta.enterprise.cdi-parent:4.0.1,jetty-project - org.eclipse.jetty:jetty-project:9.4.46.v20220331,jakarta.el-api - jakarta.el:jakarta.el-api:5.0.1,org.eclipse.equinox.p2.updatesite - org.eclipse.platform:org.eclipse.equinox.p2.updatesite:1.2.300,flexmark-ext-superscript - com.vladsch.flexmark:flexmark-ext-superscript:0.42.14,protocols - software.amazon.awssdk:protocols:2.10.35,flexmark-ext-typographic - com.vladsch.flexmark:flexmark-ext-typographic:0.42.14,jsr305 - com.google.code.findbugs:jsr305:2.0.1,wagon-http-lightweight - org.apache.maven.wagon:wagon-http-lightweight:1.0-beta-6,org.eclipse.equinox.frameworkadmin.equinox - org.eclipse.platform:org.eclipse.equinox.frameworkadmin.equinox:1.2.400,plexus-utils - org.codehaus.plexus:plexus-utils:3.5.1,junit-bom - org.junit:junit-bom:5.9.1,aws-core - software.amazon.awssdk:aws-core:2.10.35,ecf-parent - org.eclipse.ecf:ecf-parent:1.0.0,target-platform-configuration - org.eclipse.tycho:target-platform-configuration:3.0.0,doxia-decoration-model - org.apache.maven.doxia:doxia-decoration-model:1.11.1,wagon-ssh-external - org.apache.maven.wagon:wagon-ssh-external:1.0-beta-6,jakarta.xml.bind-api-parent - jakarta.xml.bind:jakarta.xml.bind-api-parent:4.0.0,doxia-logging-api - org.apache.maven.doxia:doxia-logging-api:1.11.1,animal-sniffer-parent - org.codehaus.mojo:animal-sniffer-parent:1.9,jflac-parent - org.jflac:jflac-parent:1.5.2,services - software.amazon.awssdk:services:2.10.35,spring-integration-bom - org.springframework.integration:spring-integration-bom:5.4.3,netty-buffer - io.netty:netty-buffer:4.1.42.Final,kotlinx-coroutines-bom - org.jetbrains.kotlinx:kotlinx-coroutines-bom:1.4.2,junit - junit:junit:4.13.2,animal-sniffer-annotations - org.codehaus.mojo:animal-sniffer-annotations:1.9,metrics-parent - io.dropwizard.metrics:metrics-parent:4.1.17,maven-plugin-testing-harness - org.apache.maven.plugin-testing:maven-plugin-testing-harness:2.1,flexmark-ext-wikilink - com.vladsch.flexmark:flexmark-ext-wikilink:0.42.14,netty-transport - io.netty:netty-transport:4.1.42.Final,aws-xml-protocol - software.amazon.awssdk:aws-xml-protocol:2.10.35,jackrabbit-jcr-commons - org.apache.jackrabbit:jackrabbit-jcr-commons:1.5.0,org.eclipse.osgi.compatibility.state - org.eclipse.platform:org.eclipse.osgi.compatibility.state:1.2.700,flexmark-ext-footnotes - com.vladsch.flexmark:flexmark-ext-footnotes:0.42.14,doxia-module-twiki - org.apache.maven.doxia:doxia-module-twiki:1.11.1,org.eclipse.equinox.p2.core - org.eclipse.platform:org.eclipse.equinox.p2.core:2.10.100,org.eclipse.equinox.p2.director - org.eclipse.platform:org.eclipse.equinox.p2.director:2.6.100,org.eclipse.sisu.plexus - org.eclipse.sisu:org.eclipse.sisu.plexus:0.3.5,org.eclipse.ecf.filetransfer - org.eclipse.ecf:org.eclipse.ecf.filetransfer:5.1.102,flexmark-ext-xwiki-macros - com.vladsch.flexmark:flexmark-ext-xwiki-macros:0.42.14,maven-archiver - org.apache.maven:maven-archiver:3.5.2,junit-jupiter-api - org.junit.jupiter:junit-jupiter-api:5.8.1,maven-reporting-api - org.apache.maven.reporting:maven-reporting-api:3.1.1,sisu-equinox - org.eclipse.tycho:sisu-equinox:2.7.5,jakarta.resource-api - jakarta.resource:jakarta.resource-api:2.1.0,ojdbc-bom - com.oracle.database.jdbc:ojdbc-bom:19.8.0.0,jsoup - org.jsoup:jsoup:1.10.2,plexus-components - org.codehaus.plexus:plexus-components:4.0,aether-util - org.sonatype.aether:aether-util:1.7,fest-assert - org.easytesting:fest-assert:1.4,flexmark-ext-ins - com.vladsch.flexmark:flexmark-ext-ins:0.42.14,plexus-compiler-manager - org.codehaus.plexus:plexus-compiler-manager:2.8.4,apache-client - software.amazon.awssdk:apache-client:2.10.35,nekohtml - nekohtml:nekohtml:1.9.6.2,org.eclipse.core.jobs - org.eclipse.platform:org.eclipse.core.jobs:3.15.0,guice-bean - org.sonatype.sisu.inject:guice-bean:1.4.2,batch-api-parent - jakarta.batch:batch-api-parent:2.1.1,weld-api-bom - org.jboss.weld:weld-api-bom:1.0,slf4j-api - org.slf4j:slf4j-api:2.0.6,org.eclipse.ecf.provider.filetransfer - org.eclipse.ecf:org.eclipse.ecf.provider.filetransfer:3.3.0,mockito-all - org.mockito:mockito-all:1.10.19,flexmark-ext-abbreviation - com.vladsch.flexmark:flexmark-ext-abbreviation:0.42.14,maven-settings - org.apache.maven:maven-settings:3.2.5,ow2 - org.ow2:ow2:1.5.1,org.eclipse.sisu.inject - org.eclipse.sisu:org.eclipse.sisu.inject:0.3.5,wagon-ssh - org.apache.maven.wagon:wagon-ssh:1.0-beta-6,maven-shared-components - org.apache.maven.shared:maven-shared-components:39,jetty-io - org.eclipse.jetty:jetty-io:9.4.46.v20220331,reactive-streams - org.reactivestreams:reactive-streams:1.0.2,flexmark-ext-gfm-issues - com.vladsch.flexmark:flexmark-ext-gfm-issues:0.42.14,hamcrest-parent - org.hamcrest:hamcrest-parent:1.3,netty-bom - io.netty:netty-bom:4.1.58.Final,tycho - org.eclipse.tycho:tycho:3.0.0,groovy-bom - org.codehaus.groovy:groovy-bom:2.5.14,wagon-provider-api - org.apache.maven.wagon:wagon-provider-api:1.0-beta-6,sisu-equinox-api - org.eclipse.tycho:sisu-equinox-api:2.7.5,jackson-annotations - com.fasterxml.jackson.core:jackson-annotations:2.10.0,maven-gpg-plugin - org.apache.maven.plugins:maven-gpg-plugin:1.6,sisu-osgi - org.eclipse.tycho:sisu-osgi:3.0.0,maven-reporting - org.apache.maven.reporting:maven-reporting:2.2.1,junit-platform-engine - org.junit.platform:junit-platform-engine:1.8.1,spring-security-bom - org.springframework.security:spring-security-bom:5.4.2,doxia-module-markdown - org.apache.maven.doxia:doxia-module-markdown:1.11.1,org.eclipse.equinox.p2.touchpoint.natives - org.eclipse.platform:org.eclipse.equinox.p2.touchpoint.natives:1.4.400,decentxml - de.pdark:decentxml:1.4,org.eclipse.tycho.embedder.shared - org.eclipse.tycho:org.eclipse.tycho.embedder.shared:3.0.0,jakarta.authentication-api - jakarta.authentication:jakarta.authentication-api:3.0.0,netty-transport-native-unix-common - io.netty:netty-transport-native-unix-common:4.1.42.Final,plexus-containers - org.codehaus.plexus:plexus-containers:2.1.1,oro - oro:oro:2.0.8,spice-parent - org.sonatype.spice:spice-parent:17,maven-core - org.apache.maven:maven-core:3.2.5,snappy - org.iq80.snappy:snappy:0.4,flexmark-profile-pegdown - com.vladsch.flexmark:flexmark-profile-pegdown:0.42.14,org.osgi.namespace.extender - org.osgi:org.osgi.namespace.extender:1.0.1,netty-common - io.netty:netty-common:4.1.42.Final,velocity-tools - org.apache.velocity:velocity-tools:2.0,sdk-core - software.amazon.awssdk:sdk-core:2.10.35,maven-dependency-tree - org.apache.maven.shared:maven-dependency-tree:3.2.1,doxia-module-confluence - org.apache.maven.doxia:doxia-module-confluence:1.11.1,plexus-java - org.codehaus.plexus:plexus-java:0.9.10,plexus-i18n - org.codehaus.plexus:plexus-i18n:1.0-beta-10,junit-platform-launcher - org.junit.platform:junit-platform-launcher:1.8.1,jflac-codec - org.jflac:jflac-codec:1.5.2,doxia-sink-api - org.apache.maven.doxia:doxia-sink-api:1.11.1,jackson-databind - com.fasterxml.jackson.core:jackson-databind:2.10.0,jakarta.ws.rs-api - jakarta.ws.rs:jakarta.ws.rs-api:3.1.0,jakarta.annotation-api - jakarta.annotation:jakarta.annotation-api:2.1.1,flexmark-ext-autolink - com.vladsch.flexmark:flexmark-ext-autolink:0.42.14,mockito-core - org.mockito:mockito-core:1.9.5,netty-parent - io.netty:netty-parent:4.1.42.Final,apiguardian-api - org.apiguardian:apiguardian-api:1.1.2,sisu-inject - org.eclipse.sisu:sisu-inject:0.3.5,junit-jupiter-engine - org.junit.jupiter:junit-jupiter-engine:5.8.1,guice-parent - org.sonatype.sisu.inject:guice-parent:3.2.3,spring-aop - org.springframework:spring-aop:5.3.3,jakarta.servlet.jsp-api - jakarta.servlet.jsp:jakarta.servlet.jsp-api:3.1.0,p2-maven-plugin - org.eclipse.tycho:p2-maven-plugin:3.0.0,maven-antrun-plugin - org.apache.maven.plugins:maven-antrun-plugin:3.1.0,org.eclipse.ecf - org.eclipse.ecf:org.eclipse.ecf:3.11.0,tritonus-all - com.googlecode.soundlibs:tritonus-all:0.3.7.2,spring-session-bom - org.springframework.session:spring-session-bom:2020.0.1,flexmark-all - com.vladsch.flexmark:flexmark-all:0.42.14,slf4j-jdk14 - org.slf4j:slf4j-jdk14:1.5.6,jakarta.mail-api - jakarta.mail:jakarta.mail-api:2.1.0,metrics-bom - io.dropwizard.metrics:metrics-bom:4.1.17,reactor-bom - io.projectreactor:reactor-bom:2020.0.3,netty-resolver - io.netty:netty-resolver:4.1.42.Final,jlayer - com.googlecode.soundlibs:jlayer:1.0.1.4,annotations - software.amazon.awssdk:annotations:2.10.35,jsr250-api - javax.annotation:jsr250-api:1.0,hamcrest-library - org.hamcrest:hamcrest-library:1.3,sisu-equinox-embedder - org.eclipse.tycho:sisu-equinox-embedder:3.0.0,jsch - com.jcraft:jsch:0.1.38,commons-beanutils - commons-beanutils:commons-beanutils:1.7.0,org.eclipse.osgi - org.eclipse.platform:org.eclipse.osgi:3.18.0,jboss-parent - org.jboss:jboss-parent:36,commons-collections - commons-collections:commons-collections:3.2.2,org.eclipse.equinox.p2.metadata - org.eclipse.platform:org.eclipse.equinox.p2.metadata:2.7.100,surefire-booter - org.apache.maven.surefire:surefire-booter:2.22.2,org.apache.felix.scr - org.apache.felix:org.apache.felix.scr:2.2.2,maven-plugin-descriptor - org.apache.maven:maven-plugin-descriptor:2.2.1,maven-settings-builder - org.apache.maven:maven-settings-builder:3.2.5,org.eclipse.equinox.p2.transport.ecf - org.eclipse.platform:org.eclipse.equinox.p2.transport.ecf:1.3.300,jakarta.websocket-api - jakarta.websocket:jakarta.websocket-api:2.1.0,jakarta.activation-api - jakarta.activation:jakarta.activation-api:2.1.0,flexmark-ext-jekyll-tag - com.vladsch.flexmark:flexmark-ext-jekyll-tag:0.42.14,org.osgi.service.repository - org.osgi:org.osgi.service.repository:1.1.0,plexus-compiler-javac - org.codehaus.plexus:plexus-compiler-javac:2.8.4,jvnet-parent - net.java:jvnet-parent:5,plexus-io - org.codehaus.plexus:plexus-io:3.4.1,biz.aQute.bndlib - biz.aQute.bnd:biz.aQute.bndlib:6.3.1,org.eclipse.equinox.p2.director.app - org.eclipse.platform:org.eclipse.equinox.p2.director.app:1.2.200,jetty-bom - org.eclipse.jetty:jetty-bom:9.4.35.v20201120,weld-api-parent - org.jboss.weld:weld-api-parent:1.0,tycho-metadata-model - org.eclipse.tycho:tycho-metadata-model:3.0.0,flexmark-ext-gfm-strikethrough - com.vladsch.flexmark:flexmark-ext-gfm-strikethrough:0.42.14,velocity - org.apache.velocity:velocity:1.7,wagon-http - org.apache.maven.wagon:wagon-http:1.0-beta-6,maven-common-artifact-filters - org.apache.maven.shared:maven-common-artifact-filters:3.3.2,fest-util - org.easytesting:fest-util:1.1.6,tycho-maven-plugin - org.eclipse.tycho:tycho-maven-plugin:2.7.5,org.eclipse.ecf.identity - org.eclipse.ecf:org.eclipse.ecf.identity:3.9.402,javax.inject - javax.inject:javax.inject:1,xml-apis - xml-apis:xml-apis:1.0.b2,aws-query-protocol - software.amazon.awssdk:aws-query-protocol:2.10.35,spring-context - org.springframework:spring-context:5.3.3,org.eclipse.equinox.app - org.eclipse.platform:org.eclipse.equinox.app:1.6.300,profiles - software.amazon.awssdk:profiles:2.10.35,org.eclipse.equinox.frameworkadmin - org.eclipse.platform:org.eclipse.equinox.frameworkadmin:2.2.200,doxia-sitetools - org.apache.maven.doxia:doxia-sitetools:1.11.1,doxia-core - org.apache.maven.doxia:doxia-core:1.11.1,commons-lang3 - org.apache.commons:commons-lang3:3.12.0,org.eclipse.equinox.p2.engine - org.eclipse.platform:org.eclipse.equinox.p2.engine:2.8.100,maven-plugin-parameter-documenter - org.apache.maven:maven-plugin-parameter-documenter:2.2.1,spring-jcl - org.springframework:spring-jcl:5.3.3,maven-reporting-exec - org.apache.maven.reporting:maven-reporting-exec:1.6.0,netty-handler - io.netty:netty-handler:4.1.42.Final,genesis - org.apache.geronimo.genesis:genesis:2.0,logging-parent - org.apache.logging:logging-parent:5,sisu-equinox-launching - org.eclipse.tycho:sisu-equinox-launching:3.0.0,jakarta.json.bind-api - jakarta.json.bind:jakarta.json.bind-api:3.0.0,maven-shared-incremental - org.apache.maven.shared:maven-shared-incremental:1.1,flexmark-ext-youtube-embedded - com.vladsch.flexmark:flexmark-ext-youtube-embedded:0.42.14,plexus-interpolation - org.codehaus.plexus:plexus-interpolation:1.26,httpcomponents-parent - org.apache.httpcomponents:httpcomponents-parent:11,maven-shared-utils - org.apache.maven.shared:maven-shared-utils:3.3.4,flexmark-youtrack-converter - com.vladsch.flexmark:flexmark-youtrack-converter:0.42.14,aether-parent - org.sonatype.aether:aether-parent:1.7,httpcomponents-core - org.apache.httpcomponents:httpcomponents-core:4.4.14,maven-project - org.apache.maven:maven-project:2.2.1,netty-codec-http2 - io.netty:netty-codec-http2:4.1.42.Final,codehaus-parent - org.codehaus:codehaus-parent:3,junit-platform-suite-api - org.junit.platform:junit-platform-suite-api:1.8.1,jakarta.management.j2ee-api - jakarta.management.j2ee:jakarta.management.j2ee-api:1.1.4,jakarta.interceptor-api - jakarta.interceptor:jakarta.interceptor-api:2.1.0,commons-httpclient - commons-httpclient:commons-httpclient:3.1,plexus-velocity - org.codehaus.plexus:plexus-velocity:1.2,tycho-core - org.eclipse.tycho:tycho-core:3.0.0,ant - org.apache.ant:ant:1.9.4,sisu-osgi-api - org.eclipse.tycho:sisu-osgi-api:3.0.0,maven-repository-metadata - org.apache.maven:maven-repository-metadata:3.2.5,netty-reactive-streams - com.typesafe.netty:netty-reactive-streams:2.0.3,apache - org.apache:apache:29,tycho-bundles - org.eclipse.tycho:tycho-bundles:3.0.0,doxia-module-xhtml - org.apache.maven.doxia:doxia-module-xhtml:1.11.1,sisu-plexus - org.eclipse.sisu:sisu-plexus:0.3.5,junit-platform-suite-commons - org.junit.platform:junit-platform-suite-commons:1.8.1,maven-clean-plugin - org.apache.maven.plugins:maven-clean-plugin:3.2.0,jakarta.enterprise.lang-model - jakarta.enterprise:jakarta.enterprise.lang-model:4.0.1,maven-plugin-tools - org.apache.maven.plugin-tools:maven-plugin-tools:3.5.2,ant-parent - org.apache.ant:ant-parent:1.9.4,bom-internal - software.amazon.awssdk:bom-internal:2.10.35,sisu-inject-plexus - org.sonatype.sisu:sisu-inject-plexus:1.4.2,maven-surefire-common - org.apache.maven.surefire:maven-surefire-common:2.22.2,jakarta.batch-api - jakarta.batch:jakarta.batch-api:2.1.1,surefire - org.apache.maven.surefire:surefire:2.22.2,httpcomponents-client - org.apache.httpcomponents:httpcomponents-client:4.5.13,jaudiotagger - com.github.goxr3plus:jaudiotagger:2.2.7,org.eclipse.equinox.p2.repository.tools - org.eclipse.platform:org.eclipse.equinox.p2.repository.tools:2.3.100,regions - software.amazon.awssdk:regions:2.10.35,tycho-embedder-api - org.eclipse.tycho:tycho-embedder-api:3.0.0,jetty-server - org.eclipse.jetty:jetty-server:9.4.46.v20220331,biz.aQute.bnd.util - biz.aQute.bnd:biz.aQute.bnd.util:6.3.1,org.eclipse.equinox.p2.publisher - org.eclipse.platform:org.eclipse.equinox.p2.publisher:1.7.200,jakarta.transaction-api - jakarta.transaction:jakarta.transaction-api:2.0.1,jakarta.websocket-all - jakarta.websocket:jakarta.websocket-all:2.1.0,maven-error-diagnostics - org.apache.maven:maven-error-diagnostics:2.2.1,org.osgi.util.function - org.osgi:org.osgi.util.function:1.2.0,qdox - com.thoughtworks.qdox:qdox:2.0-M9,jetty-servlet - org.eclipse.jetty:jetty-servlet:9.4.46.v20220331,flexmark-ext-gfm-users - com.vladsch.flexmark:flexmark-ext-gfm-users:0.42.14,hamcrest - org.hamcrest:hamcrest:2.2,jakarta.faces - org.glassfish:jakarta.faces:2.3.9,jakarta.mail - com.sun.mail:jakarta.mail:1.6.4,all - jakarta.ws.rs:all:3.1.0,doxia-module-xhtml5 - org.apache.maven.doxia:doxia-module-xhtml5:1.11.1,micrometer-bom - io.micrometer:micrometer-bom:1.6.3,org.eclipse.core.runtime - org.eclipse.platform:org.eclipse.core.runtime:3.29.0,spring-data-bom - org.springframework.data:spring-data-bom:2020.0.3,plexus-compilers - org.codehaus.plexus:plexus-compilers:2.8.4,auth - software.amazon.awssdk:auth:2.10.35,org.osgi.service.component - org.osgi:org.osgi.service.component:1.5.0,org.ow2.sat4j.pom - org.ow2.sat4j:org.ow2.sat4j.pom:2.3.6,flexmark-ext-media-tags - com.vladsch.flexmark:flexmark-ext-media-tags:0.42.14,org.eclipse.tycho.core.shared - org.eclipse.tycho:org.eclipse.tycho.core.shared:3.0.0,commons-digester - commons-digester:commons-digester:1.8,jetty-webapp - org.eclipse.jetty:jetty-webapp:9.4.46.v20220331,flexmark-java - com.vladsch.flexmark:flexmark-java:0.42.14,aopalliance - aopalliance:aopalliance:1.0,arns - software.amazon.awssdk:arns:2.10.35,fest - org.easytesting:fest:1.0.8,maven-plugin-annotations - org.apache.maven.plugin-tools:maven-plugin-annotations:3.5.2,plexus-component-annotations - org.codehaus.plexus:plexus-component-annotations:2.1.1,all - com.sun.activation:all:1.2.1,all - com.sun.mail:all:1.6.4,wagon-ssh-common - org.apache.maven.wagon:wagon-ssh-common:1.0-beta-6,hamcrest-core - org.hamcrest:hamcrest-core:2.2,plexus-archiver - org.codehaus.plexus:plexus-archiver:4.7.1,arc - io.quarkus.arc:arc:2.7.1.Final,commons-collections4 - org.apache.commons:commons-collections4:4.2,flexmark - com.vladsch.flexmark:flexmark:0.42.14,jakarta.xml.soap-api - jakarta.xml.soap:jakarta.xml.soap-api:3.0.0,org.eclipse.equinox.p2.metadata.repository - org.eclipse.platform:org.eclipse.equinox.p2.metadata.repository:1.5.100,jakarta.xml.rpc-api - jakarta.xml.rpc:jakarta.xml.rpc-api:1.1.4,maven-deploy-plugin - org.apache.maven.plugins:maven-deploy-plugin:3.1.1,org.osgi.util.promise - org.osgi:org.osgi.util.promise:1.2.0,javax.annotation-api - javax.annotation:javax.annotation-api:1.3.2,jakarta.servlet-api - jakarta.servlet:jakarta.servlet-api:6.0.0,plexus-build-api - org.sonatype.plexus:plexus-build-api:0.0.7,spring-core - org.springframework:spring-core:5.3.3,commons-compress - org.apache.commons:commons-compress:1.23.0,junit-jupiter-params - org.junit.jupiter:junit-jupiter-params:5.8.1,flexmark-ext-emoji - com.vladsch.flexmark:flexmark-ext-emoji:0.42.14,surefire-api - org.apache.maven.surefire:surefire-api:2.22.2,infinispan-build-configuration-parent - org.infinispan:infinispan-build-configuration-parent:11.0.15.Final,org.eclipse.tycho.p2.tools.impl - org.eclipse.tycho:org.eclipse.tycho.p2.tools.impl:3.0.0,java-driver-bom - com.datastax.oss:java-driver-bom:4.9.0,maven-profile - org.apache.maven:maven-profile:2.2.1,jackson-parent - com.fasterxml.jackson:jackson-parent:2.12,jakarta.enterprise.deploy-api - jakarta.enterprise.deploy:jakarta.enterprise.deploy-api:1.7.2,wagon-file - org.apache.maven.wagon:wagon-file:1.0-beta-6,flexmark-jira-converter - com.vladsch.flexmark:flexmark-jira-converter:0.42.14,maven-site-plugin - org.apache.maven.plugins:maven-site-plugin:3.12.1,jakarta.inject-api - jakarta.inject:jakarta.inject-api:2.0.1,project - org.glassfish.jersey:project:2.19,google-collections - com.google.collections:google-collections:1.0,maven-model - org.apache.maven:maven-model:3.2.5,soundlibs - com.googlecode.soundlibs:soundlibs:1.4,commons-chain - commons-chain:commons-chain:1.1,plexus-cipher - org.codehaus.plexus:plexus-cipher:2.0,aws-sdk-java-pom - software.amazon.awssdk:aws-sdk-java-pom:2.10.35,java-stream-player - com.github.goxr3plus:java-stream-player:9.0.4,management-api-parent - jakarta.management.j2ee:management-api-parent:1.1.4,jakarta.ejb-api - jakarta.ejb:jakarta.ejb-api:4.0.1,httpclient - org.apache.httpcomponents:httpclient:4.5.13,plexus-compiler-api - org.codehaus.plexus:plexus-compiler-api:2.8.4,org.eclipse.equinox.p2.artifact.repository - org.eclipse.platform:org.eclipse.equinox.p2.artifact.repository:1.5.100,maven-monitor - org.apache.maven:maven-monitor:2.2.1,spring-beans - org.springframework:spring-beans:5.3.3,maven - org.apache.maven:maven:3.2.5,plexus-compiler - org.codehaus.plexus:plexus-compiler:2.8.4,cdi-api - javax.enterprise:cdi-api:1.2,flexmark-formatter - com.vladsch.flexmark:flexmark-formatter:0.42.14,aether-impl - org.sonatype.aether:aether-impl:1.7,javax.servlet-api - javax.servlet:javax.servlet-api:3.1.0,jakarta.servlet.jsp.jstl-api - jakarta.servlet.jsp.jstl:jakarta.servlet.jsp.jstl-api:3.0.0,org.eclipse.equinox.security - org.eclipse.platform:org.eclipse.equinox.security:1.4.0,spring-framework-bom - org.springframework:spring-framework-bom:5.3.3,sisu-parent - org.sonatype.sisu:sisu-parent:1.4.2,jakarta.validation-api - jakarta.validation:jakarta.validation-api:3.0.2,netty-transport-native-epoll - io.netty:netty-transport-native-epoll:4.1.42.Final,spring-retry - org.springframework.retry:spring-retry:1.3.1,plexus-cipher - org.sonatype.plexus:plexus-cipher:1.4,plexus-container-default - org.codehaus.plexus:plexus-container-default:2.1.0,mojarra-parent - org.glassfish:mojarra-parent:2.3.9,org.eclipse.tycho.p2.tools.shared - org.eclipse.tycho:org.eclipse.tycho.p2.tools.shared:3.0.0,opentest4j - org.opentest4j:opentest4j:1.2.0,maven-plugins - org.apache.maven.plugins:maven-plugins:39,maven-surefire-plugin - org.apache.maven.plugins:maven-surefire-plugin:2.22.2,project - org.eclipse.ee4j:project:1.0.7,maven-install-plugin - org.apache.maven.plugins:maven-install-plugin:3.1.1,jakarta.xml.registry-api - jakarta.xml.registry:jakarta.xml.registry-api:1.0.10,grizzly-bom - org.glassfish.grizzly:grizzly-bom:2.4.4.payara-p8,jakarta.activation - com.sun.activation:jakarta.activation:1.2.1,maven-model-builder - org.apache.maven:maven-model-builder:3.2.5,genesis-java5-flava - org.apache.geronimo.genesis:genesis-java5-flava:2.0,jackrabbit-webdav - org.apache.jackrabbit:jackrabbit-webdav:1.5.0,jetty-security - org.eclipse.jetty:jetty-security:9.4.46.v20220331,org.eclipse.tycho.p2.resolver.impl - org.eclipse.tycho:org.eclipse.tycho.p2.resolver.impl:3.0.0,netty-codec - io.netty:netty-codec:4.1.42.Final,wagon-webdav-jackrabbit - org.apache.maven.wagon:wagon-webdav-jackrabbit:1.0-beta-6,aether-spi - org.sonatype.aether:aether-spi:1.7,jcl-over-slf4j - org.slf4j:jcl-over-slf4j:1.5.6,mp3spi - com.googlecode.soundlibs:mp3spi:1.9.5.4,aether-impl - org.eclipse.aether:aether-impl:1.0.0.v20140518,jakarta.websocket-client-api - jakarta.websocket:jakarta.websocket-client-api:2.1.0,jackson-bom - com.fasterxml.jackson:jackson-bom:2.12.6.20220326,maven-plugin-registry - org.apache.maven:maven-plugin-registry:2.2.1,maven-plugin-testing - org.apache.maven.plugin-testing:maven-plugin-testing:2.1,maven-artifact-transfer - org.apache.maven.shared:maven-artifact-transfer:0.13.1,doxia-site-renderer - org.apache.maven.doxia:doxia-site-renderer:1.11.1,forge-parent - org.sonatype.forge:forge-parent:38,flexmark-ext-macros - com.vladsch.flexmark:flexmark-ext-macros:0.42.14,netty-reactive-streams-parent - com.typesafe.netty:netty-reactive-streams-parent:2.0.3,doxia-skin-model - org.apache.maven.doxia:doxia-skin-model:1.11.1,backport-util-concurrent - backport-util-concurrent:backport-util-concurrent:3.1,doxia-module-fml - org.apache.maven.doxia:doxia-module-fml:1.11.1,zstd-jni - com.github.luben:zstd-jni:1.5.5-2,jetty-util-ajax - org.eclipse.jetty:jetty-util-ajax:9.4.46.v20220331,m2cachecleanup - ch.ringler.tools:m2cachecleanup:1.0.4,org.eclipse.core.net - org.eclipse.platform:org.eclipse.core.net:1.4.0,jakarta.jakartaee-api - jakarta.platform:jakarta.jakartaee-api:10.0.0,felix-parent - org.apache.felix:felix-parent:6,testcontainers-bom - org.testcontainers:testcontainers-bom:1.16.1,netty-codec-http - io.netty:netty-codec-http:4.1.42.Final,netty-nio-client - software.amazon.awssdk:netty-nio-client:2.10.35,maven-plugin-api - org.apache.maven:maven-plugin-api:3.2.5,surefire-logger-api - org.apache.maven.surefire:surefire-logger-api:2.22.2,log4j-bom - org.apache.logging.log4j:log4j-bom:2.18.0,bcpg-jdk15on - org.bouncycastle:bcpg-jdk15on:1.70,junit-platform-commons - org.junit.platform:junit-platform-commons:1.8.1,jorbis - com.googlecode.soundlibs:jorbis:0.0.17-2,jakarta.xml.bind-api - jakarta.xml.bind:jakarta.xml.bind-api:4.0.0,flexmark-ext-tables - com.vladsch.flexmark:flexmark-ext-tables:0.42.14,<![CDATA[,<!-- ==> expected: <1> but was: <0>
[INFO]
[ERROR] Tests run: 177, Failures: 4, Errors: 0, Skipped: 0
[INFO]
[INFO] ------------------------------------------------------------------------
[INFO] Reactor Summary:
[INFO]
[INFO] lemminx-maven 0.10.2-SNAPSHOT ...................... FAILURE [02:55 min]
[INFO] lemminx-maven-parent 0.0.1-SNAPSHOT ................ SKIPPED
[INFO] ------------------------------------------------------------------------
[INFO] BUILD FAILURE
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  02:55 min
[INFO] Finished at: 2023-11-08T19:21:04+01:00
[INFO] ------------------------------------------------------------------------
[ERROR] Failed to execute goal org.apache.maven.plugins:maven-surefire-plugin:3.2.2:test (default-test) on project lemminx-maven: There are test failures.
[ERROR]