### PR TITLE
Consider profiles in the maven.config as well

### DIFF
--- a/lemminx-maven/src/test/java/org/eclipse/lemminx/extensions/maven/participants/hover/MavenHoverParticipantVerionWithPropertyTest.java
+++ b/lemminx-maven/src/test/java/org/eclipse/lemminx/extensions/maven/participants/hover/MavenHoverParticipantVerionWithPropertyTest.java
@@ -9,6 +9,7 @@
 package org.eclipse.lemminx.extensions.maven.participants.hover;
 
 import static org.eclipse.lemminx.extensions.maven.utils.MavenLemminxTestsUtils.createDOMDocument;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.IOException;
@@ -58,6 +59,27 @@ class MavenHoverParticipantVerionWithPropertyTest {
 		value = hover.getContents().getRight().getValue();
 		System.out.println("testPluginManagementPluginWithVerionProperty: on version: " + value);
  		assertTrue((hover.getContents().getRight().getValue().contains("1.8")));
+	}
+
+	@Test
+	void testPluginWithVersionPropertyFromMavenConfig()
+			throws IOException, InterruptedException, ExecutionException, URISyntaxException {
+		DOMDocument document = createDOMDocument("/maven.config/properties/pom.xml", languageService);
+		Hover hover = languageService.doHover(document, new Position(14, 32), new SharedSettings());
+		assertNotNull(hover, "Hover not found, property from .mvn/maven.config missing?");
+		String value = hover.getContents().getRight().getValue();
+		assertTrue(value.contains("antrun.plugin.version"));
+		assertTrue(value.contains("1.8"));
+		assertTrue(value.contains("The property is defined in the user properties"));
+	}
+
+	@Test
+	void testPluginWithVersionPropertyFromMavenConfigProfile()
+			throws IOException, InterruptedException, ExecutionException, URISyntaxException {
+		DOMDocument document = createDOMDocument("/maven.config/properties/pom.xml", languageService);
+		Hover hover = languageService.doHover(document, new Position(22, 28), new SharedSettings());
+		assertNotNull(hover, "Hover not found, property from profile activated in .mvn/maven.config missing?");
+		assertTrue((hover.getContents().getRight().getValue().contains("3.5.1")));
 	}
 
 	@Test

--- a/lemminx-maven/src/test/resources/maven.config/properties/.mvn/maven.config
+++ b/lemminx-maven/src/test/resources/maven.config/properties/.mvn/maven.config
@@ -1,0 +1,2 @@
+-Dantrun.plugin.version=1.8
+-Ptestme

--- a/lemminx-maven/src/test/resources/maven.config/properties/pom.xml
+++ b/lemminx-maven/src/test/resources/maven.config/properties/pom.xml
@@ -1,0 +1,44 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <groupId>foo.bar</groupId>
+    <artifactId>test-hover-with-properties-from-maven-config</artifactId>
+    <version>0.0.1-SNAPSHOT</version>
+    <properties>
+        <maven.version>3.0</maven.version>
+    </properties>
+    <build>
+        <pluginManagement>
+            <plugins>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-antrun-plugin</artifactId>
+                    <version>${antrun.plugin.version}</version>
+                </plugin>
+            </plugins>
+        </pluginManagement>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>${compiler.plugin.version}</version>
+            </plugin>
+        </plugins>
+    </build>
+    <dependencies>
+        <dependency>
+            <groupId>org.apache.maven</groupId>
+            <artifactId>maven-embedder</artifactId>
+            <version>${maven.version}</version>
+            <scope>compile</scope>
+        </dependency> 
+    </dependencies>
+    
+    <profiles>
+		<profile>
+			<id>testme</id>			
+			<properties>
+		        <compiler.plugin.version>3.5.1</compiler.plugin.version>
+			</properties>
+		</profile>
+	</profiles>
+</project>


### PR DESCRIPTION
One can define profiles in the .mvn/maven.config file but currently these are ignored by lemminx leading to unexpected or even fault project models.

This now parses the profile option form the maven config and pass them to the building request.

Like we do in m2e already, @mickaelistria do you can review?