### PR TITLE
Use the old deprecated constant for user properties

### DIFF
--- a/lemminx-maven/src/main/java/org/eclipse/lemminx/extensions/maven/project/MavenProjectCache.java
+++ b/lemminx-maven/src/main/java/org/eclipse/lemminx/extensions/maven/project/MavenProjectCache.java
@@ -112,6 +112,11 @@ public class MavenProjectCache {
 	}
 	
 	class ProjectBuildManager {
+		private static final char ACTIVATE_PROFILES = CLIManager.ACTIVATE_PROFILES;
+
+		@SuppressWarnings("deprecation")
+		private static final char SET_USER_PROPERTY = CLIManager.SET_SYSTEM_PROPERTY;
+
 		private static final int CORE_POOL_SIZE = 10;
 
 		private Map<Object, BuildProjectRunnable> toProcess = new HashMap<>();
@@ -454,8 +459,8 @@ public class MavenProjectCache {
 							args = lines.filter(arg -> !arg.isEmpty()).toArray(String[]::new);
 						}
 						CommandLine commandline = manager.parse(args);
-						if (commandline.hasOption(CLIManager.SET_USER_PROPERTY)) {
-							String[] configUserProperties = commandline.getOptionValues(CLIManager.SET_USER_PROPERTY);
+						if (commandline.hasOption(SET_USER_PROPERTY)) {
+							String[] configUserProperties = commandline.getOptionValues(SET_USER_PROPERTY);
 							if (configUserProperties != null) {
 								for (String property : configUserProperties) {
 									int index = property.indexOf('=');
@@ -468,8 +473,8 @@ public class MavenProjectCache {
 								}
 							}
 						}
-						if (commandline.hasOption(CLIManager.ACTIVATE_PROFILES)) {
-							String[] profileOptionValues = commandline.getOptionValues(CLIManager.ACTIVATE_PROFILES);
+						if (commandline.hasOption(ACTIVATE_PROFILES)) {
+							String[] profileOptionValues = commandline.getOptionValues(ACTIVATE_PROFILES);
 							if (profileOptionValues != null) {
 								for (String profileOptionValue : profileOptionValues) {
 									StringTokenizer tokenizer = new StringTokenizer(profileOptionValue, ",");


### PR DESCRIPTION
It seems that under some circumstances using the
CLIManager.SET_USER_PROPERTY badly fails, instead using the deprecated one CLIManager.SET_SYSTEM_PROPERTY fix the problem, so unless the one is really gone use the deprecated field and suppress the warning.