### PR TITLE
Add OSGi metadata to the manifest of lemminx-maven

### DIFF
--- a/lemminx-maven/bnd.bnd
+++ b/lemminx-maven/bnd.bnd
@@ -1,0 +1,1 @@
+-exportcontents: org.eclipse.lemminx.extensions.maven.*

--- a/lemminx-maven/pom.xml
+++ b/lemminx-maven/pom.xml
@@ -177,6 +177,30 @@
 				</configuration>
 			</plugin>
 			<plugin>
+				<groupId>biz.aQute.bnd</groupId>
+				<artifactId>bnd-maven-plugin</artifactId>
+				<version>7.0.0</version>
+				<executions>
+					<execution>
+						<id>bnd-process</id>
+						<goals>
+							<goal>bnd-process</goal>
+						</goals>
+					</execution>
+				</executions>
+			</plugin>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-jar-plugin</artifactId>
+				<version>3.3.0</version>
+				<configuration>
+					<archive>
+						<manifestFile>
+							${project.build.outputDirectory}/META-INF/MANIFEST.MF</manifestFile>
+					</archive>
+				</configuration>
+			</plugin>
+			<plugin>
 				<artifactId>maven-assembly-plugin</artifactId>
 				<version>3.6.0</version>
 				<executions>


### PR DESCRIPTION
currently the lemminx-maven does not ship any OSGi metadata what makes it hard to use inside OSGi or even using OSGi techniques (e.g. to compute all its required dependencies using a resolver).

As shipping OSGI metadata only has the cost of a few bytes in the manifest and many libraries already doing so it seems good to add them here as well.