### PR TITLE
Satisfy preconditions before running DownloadArtifactsTest

### DIFF
--- a/lemminx-maven/pom.xml
+++ b/lemminx-maven/pom.xml
@@ -49,6 +49,12 @@
 			<version>${junit-jupiter.version}</version>
 			<scope>test</scope>
 		</dependency>
+		<dependency>
+			<groupId>org.hamcrest</groupId>
+			<artifactId>hamcrest-core</artifactId>
+			<version>3.0</version>
+			<scope>test</scope>
+		</dependency>
 
 		<dependency>
 			<groupId>org.eclipse.lemminx</groupId>

--- a/lemminx-maven/src/test/java/org/eclipse/lemminx/extensions/maven/participants/hover/DownloadArtifactsTest.java
+++ b/lemminx-maven/src/test/java/org/eclipse/lemminx/extensions/maven/participants/hover/DownloadArtifactsTest.java
@@ -41,6 +41,7 @@ public class DownloadArtifactsTest {
 	@BeforeEach
 	public void setUp() throws IOException {
 		languageService = new MavenLanguageService();
+		languageService.initializeIfNeeded();
 	}
 
 	@AfterEach
@@ -62,7 +63,6 @@ public class DownloadArtifactsTest {
 	@Timeout(value = 60, unit = TimeUnit.SECONDS)
 	public void testDownloadArtifactOnHover()
 			throws IOException, InterruptedException, URISyntaxException {
-		languageService.initializeIfNeeded();
 		File mavenRepo = languageService.getExtensions().stream() //
 				.filter(MavenLemminxExtension.class::isInstance) //
 				.map(MavenLemminxExtension.class::cast) //
@@ -88,7 +88,6 @@ public class DownloadArtifactsTest {
 	@Timeout(15000)
 	public void testDownloadNonCentralArtifactOnHover()
 			throws IOException, URISyntaxException {
-		languageService.initializeIfNeeded();
 		File mavenRepo = languageService.getExtensions().stream() //
 				.filter(MavenLemminxExtension.class::isInstance) //
 				.map(MavenLemminxExtension.class::cast) //

--- a/lemminx-maven/src/test/java/org/eclipse/lemminx/extensions/maven/participants/hover/DownloadArtifactsTest.java
+++ b/lemminx-maven/src/test/java/org/eclipse/lemminx/extensions/maven/participants/hover/DownloadArtifactsTest.java
@@ -61,7 +61,7 @@ public class DownloadArtifactsTest {
 	@Test
 	@Timeout(value = 60, unit = TimeUnit.SECONDS)
 	public void testDownloadArtifactOnHover()
-			throws IOException, InterruptedException, ExecutionException, URISyntaxException {
+			throws IOException, InterruptedException, URISyntaxException {
 		languageService.initializeIfNeeded();
 		File mavenRepo = languageService.getExtensions().stream() //
 				.filter(MavenLemminxExtension.class::isInstance) //
@@ -87,7 +87,7 @@ public class DownloadArtifactsTest {
 	@Test
 	@Timeout(15000)
 	public void testDownloadNonCentralArtifactOnHover()
-			throws IOException, InterruptedException, ExecutionException, URISyntaxException {
+			throws IOException, URISyntaxException {
 		languageService.initializeIfNeeded();
 		File mavenRepo = languageService.getExtensions().stream() //
 				.filter(MavenLemminxExtension.class::isInstance) //

--- a/lemminx-maven/src/test/java/org/eclipse/lemminx/extensions/maven/participants/hover/DownloadArtifactsTest.java
+++ b/lemminx-maven/src/test/java/org/eclipse/lemminx/extensions/maven/participants/hover/DownloadArtifactsTest.java
@@ -8,8 +8,10 @@
  *******************************************************************************/
 package org.eclipse.lemminx.extensions.maven.participants.hover;
 
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.collection.IsArrayWithSize.emptyArray;
+import static org.hamcrest.core.IsNot.not;
+import static org.hamcrest.io.FileMatchers.anExistingDirectory;
 
 import java.io.File;
 import java.io.IOException;
@@ -77,7 +79,7 @@ public class DownloadArtifactsTest {
 	public void testDownloadArtifactOnHover()
 			throws IOException, InterruptedException, URISyntaxException {
 		File artifactDirectory = new File(mavenRepo, "org/glassfish/jersey/project/2.19");
-		assertFalse(artifactDirectory.exists());
+		assertThat(artifactDirectory, not(anExistingDirectory()));
 		final DOMDocument document = createDOMDocument("/pom-remote-artifact-download-hover.xml");
 		final Position position = new Position(14, 18);
 		Hover hover;
@@ -86,8 +88,8 @@ public class DownloadArtifactsTest {
 			Thread.sleep(500);
 		} while (hover == null);
 
-		assertTrue(artifactDirectory.exists());
-		assertTrue(artifactDirectory.listFiles().length > 0);
+		assertThat(artifactDirectory, anExistingDirectory());
+		assertThat(artifactDirectory.listFiles(), not(emptyArray()));
 	}
 
 	@Test
@@ -95,13 +97,13 @@ public class DownloadArtifactsTest {
 	public void testDownloadNonCentralArtifactOnHover()
 			throws IOException, URISyntaxException {
 		File artifactDirectory = new File(mavenRepo, "com/github/goxr3plus/java-stream-player/9.0.4");
-		assertFalse(artifactDirectory.exists());
+		assertThat(artifactDirectory, not(anExistingDirectory()));
 		final DOMDocument document = createDOMDocument("/pom-remote-artifact-non-central-download-hover.xml");
 		final Position position = new Position(14, 20);
 		languageService.doHover(document, position, new SharedSettings());
 
-		assertTrue(artifactDirectory.exists());
-		assertTrue(artifactDirectory.listFiles().length > 0);
+		assertThat(artifactDirectory, anExistingDirectory());
+		assertThat(artifactDirectory.listFiles(), not(emptyArray()));
 	}
 
 }

--- a/lemminx-maven/src/test/java/org/eclipse/lemminx/extensions/maven/participants/hover/DownloadArtifactsTest.java
+++ b/lemminx-maven/src/test/java/org/eclipse/lemminx/extensions/maven/participants/hover/DownloadArtifactsTest.java
@@ -18,6 +18,9 @@ import java.util.Properties;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 
+import org.apache.maven.execution.MavenSession;
+import org.eclipse.aether.RepositorySystemSession;
+import org.eclipse.aether.repository.LocalRepository;
 import org.eclipse.lemminx.dom.DOMDocument;
 import org.eclipse.lemminx.extensions.maven.MavenLanguageService;
 import org.eclipse.lemminx.extensions.maven.MavenLemminxExtension;
@@ -37,11 +40,21 @@ import org.junit.jupiter.api.extension.ExtendWith;
 public class DownloadArtifactsTest {
 
 	private XMLLanguageService languageService;
+	private File mavenRepo;
 
 	@BeforeEach
 	public void setUp() throws IOException {
 		languageService = new MavenLanguageService();
 		languageService.initializeIfNeeded();
+		mavenRepo = languageService.getExtensions().stream() //
+				.filter(MavenLemminxExtension.class::isInstance) //
+				.map(MavenLemminxExtension.class::cast) //
+				.findAny() //
+				.map(MavenLemminxExtension::getMavenSession) //
+				.map(MavenSession::getRepositorySession) //
+				.map(RepositorySystemSession::getLocalRepository) //
+				.map(LocalRepository::getBasedir) //
+				.get();
 	}
 
 	@AfterEach
@@ -63,13 +76,6 @@ public class DownloadArtifactsTest {
 	@Timeout(value = 60, unit = TimeUnit.SECONDS)
 	public void testDownloadArtifactOnHover()
 			throws IOException, InterruptedException, URISyntaxException {
-		File mavenRepo = languageService.getExtensions().stream() //
-				.filter(MavenLemminxExtension.class::isInstance) //
-				.map(MavenLemminxExtension.class::cast) //
-				.findAny() //
-				.map(mavenLemminxPlugin -> mavenLemminxPlugin.getMavenSession().getRepositorySession()
-						.getLocalRepository().getBasedir())
-				.get();
 		File artifactDirectory = new File(mavenRepo, "org/glassfish/jersey/project/2.19");
 		final DOMDocument document = createDOMDocument("/pom-remote-artifact-download-hover.xml");
 		final Position position = new Position(14, 18);
@@ -88,14 +94,6 @@ public class DownloadArtifactsTest {
 	@Timeout(15000)
 	public void testDownloadNonCentralArtifactOnHover()
 			throws IOException, URISyntaxException {
-		File mavenRepo = languageService.getExtensions().stream() //
-				.filter(MavenLemminxExtension.class::isInstance) //
-				.map(MavenLemminxExtension.class::cast) //
-				.findAny() //
-				.map(mavenLemminxPlugin -> mavenLemminxPlugin.getMavenSession().getRepositorySession()
-						.getLocalRepository().getBasedir())
-				.get();
-
 		File artifactDirectory = new File(mavenRepo, "com/github/goxr3plus/java-stream-player/9.0.4");
 		final DOMDocument document = createDOMDocument("/pom-remote-artifact-non-central-download-hover.xml");
 		final Position position = new Position(14, 20);

--- a/lemminx-maven/src/test/java/org/eclipse/lemminx/extensions/maven/participants/hover/DownloadArtifactsTest.java
+++ b/lemminx-maven/src/test/java/org/eclipse/lemminx/extensions/maven/participants/hover/DownloadArtifactsTest.java
@@ -77,9 +77,9 @@ public class DownloadArtifactsTest {
 	public void testDownloadArtifactOnHover()
 			throws IOException, InterruptedException, URISyntaxException {
 		File artifactDirectory = new File(mavenRepo, "org/glassfish/jersey/project/2.19");
+		assertFalse(artifactDirectory.exists());
 		final DOMDocument document = createDOMDocument("/pom-remote-artifact-download-hover.xml");
 		final Position position = new Position(14, 18);
-		assertFalse(artifactDirectory.exists());
 		Hover hover;
 		do {
 			hover = languageService.doHover(document, position, new SharedSettings());
@@ -95,9 +95,9 @@ public class DownloadArtifactsTest {
 	public void testDownloadNonCentralArtifactOnHover()
 			throws IOException, URISyntaxException {
 		File artifactDirectory = new File(mavenRepo, "com/github/goxr3plus/java-stream-player/9.0.4");
+		assertFalse(artifactDirectory.exists());
 		final DOMDocument document = createDOMDocument("/pom-remote-artifact-non-central-download-hover.xml");
 		final Position position = new Position(14, 20);
-		assertFalse(artifactDirectory.exists());
 		languageService.doHover(document, position, new SharedSettings());
 
 		assertTrue(artifactDirectory.exists());

--- a/lemminx-maven/src/test/java/org/eclipse/lemminx/extensions/maven/participants/hover/DownloadArtifactsTest.java
+++ b/lemminx-maven/src/test/java/org/eclipse/lemminx/extensions/maven/participants/hover/DownloadArtifactsTest.java
@@ -16,6 +16,11 @@ import static org.hamcrest.io.FileMatchers.anExistingDirectory;
 import java.io.File;
 import java.io.IOException;
 import java.net.URISyntaxException;
+import java.nio.file.FileVisitResult;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.SimpleFileVisitor;
+import java.nio.file.attribute.BasicFileAttributes;
 import java.util.Properties;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
@@ -74,11 +79,29 @@ public class DownloadArtifactsTest {
 		return MavenLemminxTestsUtils.createDOMDocument(path, props, languageService);
 	}
 
+	private static void deleteRecursively(File artifactDirectory) throws IOException {
+		Files.walkFileTree(artifactDirectory.toPath(), new SimpleFileVisitor<>() {
+			@Override
+			public FileVisitResult visitFile(Path fileToDelete, BasicFileAttributes attrs) throws IOException {
+				Files.delete(fileToDelete);
+				return FileVisitResult.CONTINUE;
+			}
+
+			@Override
+			public FileVisitResult postVisitDirectory(Path directoryToDelete, IOException exception) throws IOException {
+				if (exception != null) throw exception;
+				Files.delete(directoryToDelete);
+				return FileVisitResult.CONTINUE;
+			}
+		});
+	}
+
 	@Test
 	@Timeout(value = 60, unit = TimeUnit.SECONDS)
 	public void testDownloadArtifactOnHover()
 			throws IOException, InterruptedException, URISyntaxException {
 		File artifactDirectory = new File(mavenRepo, "org/glassfish/jersey/project/2.19");
+		deleteRecursively(artifactDirectory);
 		assertThat(artifactDirectory, not(anExistingDirectory()));
 		final DOMDocument document = createDOMDocument("/pom-remote-artifact-download-hover.xml");
 		final Position position = new Position(14, 18);
@@ -97,6 +120,7 @@ public class DownloadArtifactsTest {
 	public void testDownloadNonCentralArtifactOnHover()
 			throws IOException, URISyntaxException {
 		File artifactDirectory = new File(mavenRepo, "com/github/goxr3plus/java-stream-player/9.0.4");
+		deleteRecursively(artifactDirectory);
 		assertThat(artifactDirectory, not(anExistingDirectory()));
 		final DOMDocument document = createDOMDocument("/pom-remote-artifact-non-central-download-hover.xml");
 		final Position position = new Position(14, 20);


### PR DESCRIPTION
As `DownloadArtifactsTest` tests that `XMLLanguageService` would download required dependencies into the local Maven repository, ensure that such artifacts do not exist already, i.e. from previous tests' executions.

To minimize blast radius, do not remove any other artifacts that our test methods are not interested in.

Also, more expressive Hamcrest's asserts/matchers with verbose message on failure:
```
[INFO] Results:
[ERROR] Failures:
[ERROR]   DownloadArtifactsTest.testDownloadArtifactOnHover:86
Expected: not an existing directory
    but: was </sources/eclipse-lemminx/lemminx-maven/lemminx-maven/target/.lemminx-maven/org/glassfish/jersey/project/2.19>
```