### PR TITLE
Don't fail test if artifact's directory does not exist yet

### DIFF
--- a/lemminx-maven/src/test/java/org/eclipse/lemminx/extensions/maven/participants/hover/DownloadArtifactsTest.java
+++ b/lemminx-maven/src/test/java/org/eclipse/lemminx/extensions/maven/participants/hover/DownloadArtifactsTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019-2022 Red Hat Inc. and others.
+ * Copyright (c) 2019, 2026 Red Hat Inc. and others.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/
@@ -80,6 +80,9 @@ public class DownloadArtifactsTest {
 	}
 
 	private static void deleteRecursively(File artifactDirectory) throws IOException {
+		if (!artifactDirectory.exists()) {
+			return;
+		}
 		Files.walkFileTree(artifactDirectory.toPath(), new SimpleFileVisitor<>() {
 			@Override
 			public FileVisitResult visitFile(Path fileToDelete, BasicFileAttributes attrs) throws IOException {


### PR DESCRIPTION
Follow up to #651, DownloadArtifactsTest should not fail when executed in isolation, like:

    ./mvnw clean
    ./mvnw -Dtest=org.eclipse.lemminx.extensions.maven.participants.hover.DownloadArtifactsTest test
    ...
    [INFO] Results:
    [INFO]
    [ERROR] Errors:
    [ERROR]   DownloadArtifactsTest.testDownloadArtifactOnHover:104->deleteRecursively:83 » NoSuchFile /sources/eclipse-lemminx/lemminx-maven/lemminx-maven/target/.lemminx-maven/org/glassfish/jersey/project/2.19
    [ERROR]   DownloadArtifactsTest.testDownloadNonCentralArtifactOnHover:123->deleteRecursively:83 » NoSuchFile /sources/eclipse-lemminx/lemminx-maven/lemminx-maven/target/.lemminx-maven/com/github/goxr3plus/java-stream-player/9.0.4
    [INFO]
    [ERROR] Tests run: 2, Failures: 0, Errors: 2, Skipped: 0

[1] https://github.com/eclipse-lemminx/lemminx-maven/pull/651